### PR TITLE
Shellfish exports

### DIFF
--- a/libs/shellfish/pyproject.toml
+++ b/libs/shellfish/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["hatchling"]
 
 [project]
 name = "shellfish"
-version = "0.5.1"
+version = "0.5.2"
 description = "shellfish ~ shell & file-system utils"
 readme = "README.md"
 keywords = ["dgpy", "filesystem", "fs", "shell", "typed"]

--- a/libs/shellfish/src/shellfish/__about__.py
+++ b/libs/shellfish/src/shellfish/__about__.py
@@ -7,4 +7,4 @@ __all__ = ("__description__", "__pkgroot__", "__title__", "__version__")
 __title__ = "shellfish"
 __description__ = "shellfish ~ shell & file-system utils"
 __pkgroot__ = __file__.replace("__about__.py", "").rstrip("/\\")
-__version__ = "0.5.1"
+__version__ = "0.5.2"

--- a/libs/shellfish/src/shellfish/__init__.py
+++ b/libs/shellfish/src/shellfish/__init__.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from os import path as path
+
 from asyncify import aiorun as aiorun
 from funkify import funkify as _funkify
 from shellfish import dotenv as dotenv, fs as fs, process as process, sh as sh
@@ -290,6 +292,7 @@ __all__ = (
     "mkenv",
     "move",
     "mv",
+    "path",
     "path_gen",
     "process",
     "ps",

--- a/libs/shellfish/src/shellfish/sh.py
+++ b/libs/shellfish/src/shellfish/sh.py
@@ -7,7 +7,15 @@ import signal
 import sys
 
 from functools import lru_cache
-from os import chdir, environ, fspath as _fspath, getcwd, listdir, makedirs, path
+from os import (
+    chdir,
+    environ,
+    fspath as _fspath,
+    getcwd,
+    listdir,
+    makedirs,
+    path as path,
+)
 from pathlib import Path
 from platform import system
 from shlex import quote as _quote, split as _shplit
@@ -253,6 +261,7 @@ __all__ = (
     "mkenv",
     "move",
     "mv",
+    "path",
     "path_gen",
     "popen_has_pipe_character",
     "pstderr",

--- a/uv.lock
+++ b/uv.lock
@@ -888,7 +888,7 @@ name = "importlib-metadata"
 version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7", size = 55304 }
 wheels = [
@@ -2742,7 +2742,7 @@ wheels = [
 
 [[package]]
 name = "shellfish"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "libs/shellfish" }
 dependencies = [
     { name = "aiopen" },


### PR DESCRIPTION
explicitly re-export `os.path` for shellfish`