### PR TITLE
add libs publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,56 @@
+name: publish
+
+# Publish dgpy-libs packages to PyPI via Trusted Publishing (OIDC).
+#
+# Flow: on merge to `main` (or manual dispatch) the `detect` job compares each
+# publishable lib's pyproject.toml version against PyPI and emits a matrix of
+# packages whose version is not yet published. The `publish` job builds and
+# uploads only those packages. No API tokens are stored -- each package is
+# configured once on PyPI to trust this repo + workflow + `pypi` environment.
+
+on:
+  push:
+    branches: [main]
+    paths: ["libs/**/pyproject.toml"]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.detect.outputs.matrix }}
+      any: ${{ steps.detect.outputs.any }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - id: detect
+        name: Detect unpublished versions
+        run: python scripts/pypi_publish_detect.py
+
+  publish:
+    needs: detect
+    if: needs.detect.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write # required for PyPI Trusted Publishing (OIDC)
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.detect.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+      - name: Build ${{ matrix.package }} v${{ matrix.version }}
+        run: uv build --package ${{ matrix.package }}
+      - name: Publish ${{ matrix.package }} to PyPI
+        run: uv publish

--- a/justfile
+++ b/justfile
@@ -28,6 +28,14 @@ build:
     uv build -v --package shellfish
     uv build -v --package xtyping
 
+# preview which libs would publish (versions not yet on PyPI)
+publish-check:
+    uv run python scripts/pypi_publish_detect.py
+
+# bump one lib's version, e.g. `just bump shellfish patch`
+bump pkg level="patch":
+    uv version --bump {{ level }} --package {{ pkg }}
+
 # test root + all libraries
 test: sync
     uv run pytest tests dgpydev

--- a/scripts/pypi_publish_detect.py
+++ b/scripts/pypi_publish_detect.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Detect which dgpy-libs packages have a version not yet published on PyPI.
+
+Reads each publishable lib's ``pyproject.toml`` version and compares it against
+the versions already available on PyPI. A package is selected for publishing
+when its current version string is not present on PyPI (this also covers a
+package's very first release, where PyPI returns 404).
+
+Outputs:
+- a human-readable table to stderr
+- the GitHub Actions matrix (JSON array of ``{"package", "version"}``) to stdout
+- ``matrix=`` / ``any=`` rows appended to ``$GITHUB_OUTPUT`` when running in CI
+
+Stdlib only (``tomllib`` requires Python >= 3.11); no third-party deps.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tomllib
+import urllib.error
+import urllib.request
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LIBS_DIR = REPO_ROOT / "libs"
+
+# Publishable packages. Excludes the private root (`dgpydev`) and `dgpytest`
+# (classifier "Private :: Do Not Upload"). `dgpylibs` is the publishable
+# meta-package.
+PACKAGES = [
+    "aiopen",
+    "asyncify",
+    "fmts",
+    "funkify",
+    "h5",
+    "jsonbourne",
+    "lager",
+    "listless",
+    "requires",
+    "shellfish",
+    "xtyping",
+]
+
+
+def local_version(pkg: str) -> str:
+    """Return the version declared in ``libs/<pkg>/pyproject.toml``."""
+    pyproject = LIBS_DIR / pkg / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    return str(data["project"]["version"])
+
+
+def pypi_versions(pkg: str) -> set[str]:
+    """Return the set of versions already released on PyPI for ``pkg``."""
+    url = f"https://pypi.org/pypi/{pkg}/json"
+    try:
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            data = json.load(resp)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return set()  # never published -> first release
+        raise
+    return set(data.get("releases", {}).keys())
+
+
+def main() -> None:
+    to_publish: list[dict[str, str]] = []
+    print(f"{'package':<12} {'version':<10} status", file=sys.stderr)  # noqa: T201
+    print(f"{'-' * 12} {'-' * 10} {'-' * 7}", file=sys.stderr)  # noqa: T201
+    for pkg in PACKAGES:
+        version = local_version(pkg)
+        ahead = version not in pypi_versions(pkg)
+        status = "PUBLISH" if ahead else "ok"
+        print(f"{pkg:<12} {version:<10} {status}", file=sys.stderr)  # noqa: T201
+        if ahead:
+            to_publish.append({"package": pkg, "version": version})
+
+    matrix = json.dumps(to_publish)
+    print(matrix)  # machine-readable matrix on stdout  # noqa: T201
+
+    gh_out = os.environ.get("GITHUB_OUTPUT")
+    if gh_out:
+        with open(gh_out, "a", encoding="utf-8") as fh:
+            fh.write(f"matrix={matrix}\n")
+            fh.write(f"any={'true' if to_publish else 'false'}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- adding a publish workflow that checks for any dgpy-libs that have local version higher than current pypi version, and then publishes them (needs oidc setup on ppi - if PR looks good to @jessekrubin i will do that before mergin)
- add two justfile commands - `just publish-check` to see what apps would be published, and `just bump {pkg}` to bump a version in pyproject.toml
- edit all about.py scripts to import version from pyproject.toml to avoid duplication