### PR TITLE
chore: update uv lockfile dependencies

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -241,11 +241,11 @@ css = [
 
 [[package]]
 name = "certifi"
-version = "2026.6.17"
+version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
@@ -443,14 +443,14 @@ wheels = [
 
 [[package]]
 name = "colorlog"
-version = "6.10.1"
+version = "6.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162, upload-time = "2025-10-16T16:14:11.978Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/bf/cb30a51af3aa8ce63735f77e23dcd4fc0720fe0339bcb04f77345659c277/colorlog-6.11.0.tar.gz", hash = "sha256:9d90fb53fa906c8970c18fbe46506bae1fb5f86b513b8f867db37e4ace9be7ae", size = 17734, upload-time = "2026-07-17T12:16:46.59Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c", size = 11743, upload-time = "2025-10-16T16:14:10.512Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/a1/6b71004ab0fea510230be9ce05a4059029ac847c009fcc80b1b73d6fa5ab/colorlog-6.11.0-py3-none-any.whl", hash = "sha256:f1e27d75aa2cb138f3f640c0e305b65b680ccbef6ecc034eba7e03494ffcd2a1", size = 12016, upload-time = "2026-07-17T12:16:45.3Z" },
 ]
 
 [[package]]
@@ -775,11 +775,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.30.0"
+version = "3.32.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/83/2b/8b6480a70a647035334a604d0931926de4b5cd1f57835d45ad5eed2b1a1e/filelock-3.30.0.tar.gz", hash = "sha256:1774e682dbe443bd60f9609162fc596e2c80dc84ffc2957068953406d0520090", size = 174927, upload-time = "2026-07-16T03:53:58.152Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/80/8232b582c4b318b817cf1274ba74976b07b34d35ef439b3eb948f98645a1/filelock-3.32.0.tar.gz", hash = "sha256:7be2ad23a14607ccc71808e68fe30848aeace7058ace17852f68e2a68e310402", size = 213757, upload-time = "2026-07-21T13:17:42.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/af/9b01bcf5c91e81899bb890b87bd9077732a9b3365c098e67fe77958c39ed/filelock-3.30.0-py3-none-any.whl", hash = "sha256:40632998f0772e64183bb819f086a1b9def6be1090cf1dcb9d45f46806ef279b", size = 93131, upload-time = "2026-07-16T03:53:56.727Z" },
+    { url = "https://files.pythonhosted.org/packages/06/79/b4c714bef36bc4ec2beeae1e0c124f0223888cd8c6feb1cdc56038116920/filelock-3.32.0-py3-none-any.whl", hash = "sha256:d396bea984af47333ef05e50eae7eff88c84256de6112aea0ec48a233c064fe3", size = 97732, upload-time = "2026-07-21T13:17:41.55Z" },
 ]
 
 [[package]]
@@ -1163,7 +1163,7 @@ wheels = [
 
 [[package]]
 name = "jupytext"
-version = "1.19.4"
+version = "1.19.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
@@ -1172,9 +1172,9 @@ dependencies = [
     { name = "packaging" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/52/e014296ac8f40ca783aeb73dae52e65edbb0eaae0dcdc1ea41bfaa8aebf7/jupytext-1.19.4.tar.gz", hash = "sha256:739bcd4bc12aa4fe298a38017cdb5ae27b08a6ba3a5470728d2fe9e04b155db1", size = 4581977, upload-time = "2026-06-21T21:48:58.32Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ca/473f8ebb101553fb2ea6ab1d34324d6677844c968947ac050c759d539f2c/jupytext-1.19.5.tar.gz", hash = "sha256:605026446d605aa54fd7f7fc69df6ae51c7a46053d4cebf05afdc64d66de3df0", size = 4600916, upload-time = "2026-07-21T22:00:29.198Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/e9/e2ae007456069dbe01865c69a4203a7ada6f7e337b78fc2f12e51bd3fae7/jupytext-1.19.4-py3-none-any.whl", hash = "sha256:032d4ef4bd2e96addcac780b9b1d6b5a266ca39beceaaca95bfb4f06e0b77029", size = 170889, upload-time = "2026-06-21T21:48:56.352Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/c6/76ee9dacedcd8c67d8fa53dd975613733bdd28242a4c41518ff1c8aeaa64/jupytext-1.19.5-py3-none-any.whl", hash = "sha256:af22351202171116b986fe1f4f9233a13ca4a85d5eec57a87900ed48521dbae4", size = 229246, upload-time = "2026-07-21T22:00:27.218Z" },
 ]
 
 [[package]]
@@ -1448,11 +1448,11 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.3.3"
+version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/a5/2dab368d6950e6808904dec98f54c7e726ee7be4a0c6afe00e6e011bd52d/mistune-3.3.3.tar.gz", hash = "sha256:c4c6c0c840b8637a2e9b8b6d607eb7c8f00888bf14c754409bcd339e848c2477", size = 115363, upload-time = "2026-07-09T06:18:05.268Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/92/328a294a6de83bacb95bed01f04e0eaff4e3616ee359fc821a5dfc539b02/mistune-3.3.4.tar.gz", hash = "sha256:58b5c96d6fcb61190dfe5fae498d2b2065f99cf61e9649418fd54cf1ada86dfe", size = 121426, upload-time = "2026-07-22T05:22:30.89Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/70/b1e4737b84163db5bb1dfde6f216dbfbf32783330a9989c965e121172830/mistune-3.3.3-py3-none-any.whl", hash = "sha256:99de1585e42dcbd826faa9e11a202727a5e202e4e4722a4c69ac1ff615793dd7", size = 63569, upload-time = "2026-07-09T06:18:03.839Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e4/288365afae98953bc01de09f686f40d8ee84578135aa7767d5d4e60b5278/mistune-3.3.4-py3-none-any.whl", hash = "sha256:ee015381e955e370962968befe1d729ab60fafb6a715ac6751763fbce38c8d4a", size = 66862, upload-time = "2026-07-22T05:22:29.419Z" },
 ]
 
 [[package]]
@@ -1526,7 +1526,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.7.6"
+version = "9.7.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -1541,9 +1541,9 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/cd/c05d3a530ba7934f144fb45f7203cd236adc25c7bdcc34673d202f4b0278/mkdocs_material-9.7.7.tar.gz", hash = "sha256:c0649c065b1b0512d60aad8c10f947f8e455284475239b364b610f2deb4d0855", size = 4097923, upload-time = "2026-07-17T16:21:33.156Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/21/17c1bc9e6f47c972ad66fb2ac2568f99f90f1207eeb6fc3b34d094dba7b5/mkdocs_material-9.7.7-py3-none-any.whl", hash = "sha256:8ea9bb1737a5b524a5f9dcf2e1b4ebda8274ae3008aa7845720a97083bef708f", size = 9305438, upload-time = "2026-07-17T16:21:30.017Z" },
 ]
 
 [[package]]
@@ -1993,11 +1993,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.10.0"
+version = "4.11.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0", size = 31953, upload-time = "2026-07-21T13:09:36.565Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74", size = 23247, upload-time = "2026-07-21T13:09:35.422Z" },
 ]
 
 [[package]]
@@ -2272,15 +2272,15 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.4.4"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/81/58c70036dffeccb7fe7d79d6260c69f7a28272bbd3909c29a01ea9422744/python_discovery-1.4.4.tar.gz", hash = "sha256:5cad33982d412c1f3ffb8f9ca4ea292c9680bca3942451d30b69c37fce53a4a3", size = 72212, upload-time = "2026-07-08T23:06:50.691Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/51/276f964496a5714ab9f320896195639086881c2b39c03b5ad13de84acbb8/python_discovery-1.5.0.tar.gz", hash = "sha256:3e014c6327154d3dda27939a9a0dc9c5c000439f1906d3f303b48f984bd2ecef", size = 72483, upload-time = "2026-07-21T13:14:14.641Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/ae/84bc0d2440c95772272bb6f4b3d09ccf08b2898fce89b3d4f969a9fc74e9/python_discovery-1.4.4-py3-none-any.whl", hash = "sha256:abebe9120b43453b68c908acfb1e72a19d1a959ed2cb620ad38fc57d08056dbe", size = 34181, upload-time = "2026-07-08T23:06:49.402Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7b/14882602ddee241d7984a742fcb423cb4a30fb0d6efc546ac3129fba475a/python_discovery-1.5.0-py3-none-any.whl", hash = "sha256:70c4fc61b4e7404e44f01d6fc44a715c4d685ca6cea83d295922f05891877c98", size = 34205, upload-time = "2026-07-21T13:14:13.398Z" },
 ]
 
 [[package]]
@@ -2622,88 +2622,88 @@ wheels = [
 
 [[package]]
 name = "ry"
-version = "0.0.97"
+version = "0.0.98"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0e/41/03728953671645cfce56696b627566064e20083bfe89fc9dc837827d7169/ry-0.0.97.tar.gz", hash = "sha256:554a6e1bc978014bcb1e0ab3467b213839808d0a81b50ea2f733247233b51501", size = 720517, upload-time = "2026-06-27T05:32:29.866Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/e9/c7573f033116483119dc57d2bdeec81f5544355ef9eb3cb493aaeafc4fe8/ry-0.0.98.tar.gz", hash = "sha256:a0a41e4903311cb83584b2d7ec54a5bca3277d65c2b76c23e2b141142db23eb7", size = 741488, upload-time = "2026-07-17T00:51:12.413Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/92/541ef074df735198d10eef5164b6a12c42d9a96b44da04d0319d2ad72925/ry-0.0.97-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:80acf53825d023039f392e4b4e67f66ec69abdaf5cf0c7e89d114814487767c1", size = 6290050, upload-time = "2026-06-27T05:29:59.644Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/bb/8592ff977d96520ea18d1c58433942671ff6e6f46542e152521a708164cf/ry-0.0.97-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b44dfe634e42132d384322e90ba874835f72f0c9d909db59dc89b11ba9a21c24", size = 6862142, upload-time = "2026-06-27T05:30:01.87Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/2f/460f9bbc099d40ac63b8ab305d96f9ab34919b9698cbea54cbcf06b552b7/ry-0.0.97-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8761e563bcde57277a3ed517cc0e6f83c8561f5638fca1cdae2e1a1c5c60796", size = 7028433, upload-time = "2026-06-27T05:30:03.851Z" },
-    { url = "https://files.pythonhosted.org/packages/65/8e/a33fc6597aaebd2d482288ed9da97870fd31cec021b885746183f9d4de63/ry-0.0.97-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:6ac513845c88dc289fd612c6517315e3a57ba553cc88d09de0f59af988af1d89", size = 6673811, upload-time = "2026-06-27T05:30:05.752Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/24/dbd6e9e8fcce0a08367abf160715ece9454af4654075be0d93e179901d1c/ry-0.0.97-cp311-cp311-manylinux_2_28_armv7l.whl", hash = "sha256:9489b1b5e6b65823b630500aeb586c43d0aeb08c9c3d0af41f7fe117a95cf98b", size = 6500742, upload-time = "2026-06-27T05:30:07.474Z" },
-    { url = "https://files.pythonhosted.org/packages/df/d1/d4aafc2357d566e031697818c8c6db11aef6f51aacc0f3ff82b52b95d2a5/ry-0.0.97-cp311-cp311-manylinux_2_28_ppc64le.whl", hash = "sha256:76943d379065a5f1284af477f85a4c98d29acc611ad7ccbf5a447ce3055d76ea", size = 7161301, upload-time = "2026-06-27T05:30:09.334Z" },
-    { url = "https://files.pythonhosted.org/packages/05/ee/4db2acac0ff2ec3e7c47df5cbea4e45bebfbd9c9e43cab6bcfb0578f1a1b/ry-0.0.97-cp311-cp311-manylinux_2_28_s390x.whl", hash = "sha256:0bb72d0783654e0c5867bd882eaa472c12e0a6e8e706cd25349c6b4b4f8d0db0", size = 6930389, upload-time = "2026-06-27T05:30:11.464Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/1f/2fd2a73efada0b76d5a1e85aca0235e9ff6687084d690c07db2ff2909fd6/ry-0.0.97-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c9feadd306ed3d52b70778c5b3d5b41eea78f861ef8d8fbb3465b1ea1494e5cf", size = 6805278, upload-time = "2026-06-27T05:30:13.314Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/9a/0866e97253a10fd1675492027d8986fd733176ca342a44384f7c8d3e4def/ry-0.0.97-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e1647d79ac8a5ef0299e514c868a3a67b5152ffe73ff52b7d122c16909ad9ac5", size = 6632094, upload-time = "2026-06-27T05:30:14.938Z" },
-    { url = "https://files.pythonhosted.org/packages/79/bd/7e7a945ba74e049786c7ab6bf385342f9c31454b858e0ca7bb39755b50b1/ry-0.0.97-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1f6ba6b7697a2c13f4319446192b4e8e29f0a36281d330517d8aa20844e6b9ba", size = 6781644, upload-time = "2026-06-27T05:30:16.835Z" },
-    { url = "https://files.pythonhosted.org/packages/07/68/e1840b83c2e4db7f95fbcc4442b57b034b3a85635ce9acb9084302ef449e/ry-0.0.97-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e8e1410e740186c169650dd45763187e13affe5f38b71048bf650c3f43296f03", size = 7203957, upload-time = "2026-06-27T05:30:18.586Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/42/037252de2e11a05149fdfde890c33927b181d1edc139632bffe9a1e51dba/ry-0.0.97-cp311-cp311-win32.whl", hash = "sha256:b73e888be3eb3c9e8cfa8d18577f69fd6fa59e1d565e011b409a30afa1ce3fe9", size = 5981940, upload-time = "2026-06-27T05:30:20.34Z" },
-    { url = "https://files.pythonhosted.org/packages/74/e0/7bce5c129eeb87dc2202013bf4967b403063505b28f273b90ec0cfbf1d12/ry-0.0.97-cp311-cp311-win_amd64.whl", hash = "sha256:6be66efa00f94dc91cd7defa8459c95c83eebe95c42a5f3191e3ec656a6087aa", size = 6314378, upload-time = "2026-06-27T05:30:22.685Z" },
-    { url = "https://files.pythonhosted.org/packages/86/ed/3f428e078a8e3ee9ecc640786983a0066afd2858535f7e745e42ed2cf283/ry-0.0.97-cp311-cp311-win_arm64.whl", hash = "sha256:b2b811ea45f1bfdd8359b6af20e05d94f8e3417819be1ff3a7da408b169cad6d", size = 6235785, upload-time = "2026-06-27T05:30:24.384Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/89/6ae6f85b3b81e283be485d13a40b553ab78854059688a519a3f9dece4936/ry-0.0.97-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a787a63bc2b7286d5a3c6e8ff4bcea34dd2ae3876eb0cff08a51de70965b2449", size = 6241315, upload-time = "2026-06-27T05:30:26.114Z" },
-    { url = "https://files.pythonhosted.org/packages/12/3b/e87e2befa02b0368aa42911061c26c31cbe328d61beb7ab96a69f2e0a86b/ry-0.0.97-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ee594f42eefd623357aba8cbcb88c8158b1e1c505509ccfda3a5b9e624de34c8", size = 6838304, upload-time = "2026-06-27T05:30:28.784Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0d/89316c9dee748bab46c0a8836ec2dca1e6ca922eaa69edf32fa302b5b10c/ry-0.0.97-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24d02ad39e31af013cc1b35e621cd85e32420e9fa3e765a37035c985e05605be", size = 7038825, upload-time = "2026-06-27T05:30:30.746Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/3f/abbe8d40639aeb8517277c0476d690190216068499c1292280b53bc3cd12/ry-0.0.97-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:fba46424f3256007421381b35f53a3ad30d6c867546af27ad7e07cb283c55a88", size = 6680575, upload-time = "2026-06-27T05:30:32.944Z" },
-    { url = "https://files.pythonhosted.org/packages/47/2e/34c725b45c6b9b1647133a29aad777de28ec8bda02bf9192c077932762d2/ry-0.0.97-cp312-cp312-manylinux_2_28_armv7l.whl", hash = "sha256:11c53f3dcff62c1318f8bd690dee7492850846a42ad87054edb20042046cc333", size = 6508902, upload-time = "2026-06-27T05:30:34.764Z" },
-    { url = "https://files.pythonhosted.org/packages/da/7f/45621ff7bc18bd60dd84b7314a72cfc9471f96b6f8404afaa5377a27a722/ry-0.0.97-cp312-cp312-manylinux_2_28_ppc64le.whl", hash = "sha256:0c329200fc1e0e532e8773bce90989616c4407b9048c1afaa3b4be1003f95d3a", size = 7119972, upload-time = "2026-06-27T05:30:36.408Z" },
-    { url = "https://files.pythonhosted.org/packages/37/3f/7df9a60e0630ccc3e89afa8a4cac779ad8fee5c55d68ff9e9ac59cfeee1a/ry-0.0.97-cp312-cp312-manylinux_2_28_s390x.whl", hash = "sha256:99c43bec0913dd7d3c07069cad37907457305b42e42508d6253a3751ebd82663", size = 6913514, upload-time = "2026-06-27T05:30:38.448Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/69/081c15eecd8dd26a01969676f9e88a60e0098826be96c2a2d84cea0c8cb7/ry-0.0.97-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:873999c760ee1318179f34693fed16eecb3a42c768712d481699741c902bf063", size = 6810560, upload-time = "2026-06-27T05:30:40.203Z" },
-    { url = "https://files.pythonhosted.org/packages/22/00/198493107244b5aacb7223f4d3f2e819f5ba1ae952a77e0f66a915cd5190/ry-0.0.97-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:4b1aec9b51402eebbf47615d4aefcd3b9489a76d57a274761395329604701393", size = 6637056, upload-time = "2026-06-27T05:30:42.231Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/b1/c3ceeb494b36f32526fff1df6915dac86c20999edb799ac2962be1d9e73b/ry-0.0.97-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5a7eabc436154fb4a721f0446566da3e9c1c24d29124032f88221e5e37f7fbf6", size = 6755810, upload-time = "2026-06-27T05:30:44.009Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/28/8b487cb287d2c7c154337e5235aabcf4d06da3f887e250a6d55937d0a105/ry-0.0.97-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bd25dea6b162cbe17beb1ee187c946c003586ca91ccf8961c6a4e5f4ad7b6a4b", size = 7217756, upload-time = "2026-06-27T05:30:45.839Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/1a/ccf7c316c083b394e6ab03a7736d3d12953eaf4ba4497b503682b17acf4b/ry-0.0.97-cp312-cp312-win32.whl", hash = "sha256:047cf45507d2a1166e9dff839fb9381ee77b7a25406d1e8cf93d792272ef607a", size = 5989494, upload-time = "2026-06-27T05:30:47.608Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/62/3e0582d0315c4458f03c3d9e1bfb3a5b33e94805397cc673791c2b9061ba/ry-0.0.97-cp312-cp312-win_amd64.whl", hash = "sha256:af7d0457e2f46901250a424c7bf5451ab21319858a70daeec248a0f9a76f9c1a", size = 6329757, upload-time = "2026-06-27T05:30:49.531Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/b8/c35363f41f72c4415c7bcf41656af2ee26ef69e622f52f300d3d551ec8da/ry-0.0.97-cp312-cp312-win_arm64.whl", hash = "sha256:2adfeb9aa333452be1932cb3ee5b125a8bbe17a203a8c6192d4486c6a3831b3e", size = 6241065, upload-time = "2026-06-27T05:30:51.607Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/46/1645e5890c49f5de1b71dd45d0e52e25cbd5623d7f2f1d31b26f4b9ddae5/ry-0.0.97-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c7bdcb2adb235ee7e5967534b763fd27393776629250fb15662bb856b8276caf", size = 6241618, upload-time = "2026-06-27T05:30:53.401Z" },
-    { url = "https://files.pythonhosted.org/packages/20/f7/69705aa5e6b28bcde7509a870c87c9a54a2c510c7f1dbeb0a899b52f9594/ry-0.0.97-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b6426563fa14fa52f625d0386106b61d4201a59d51f9b46c1b6f7d9d61fb719f", size = 6838163, upload-time = "2026-06-27T05:30:55.066Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/82/1a3b1ad62a7b849419313d7685728a33d1f942723350d048751cf985d1a2/ry-0.0.97-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e2741a7e00d8cfffdb8c87b4d20613ab493f33c52070ce2f0c79085d414fbeb", size = 7040502, upload-time = "2026-06-27T05:30:56.801Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/7b/8f15fba5273075b156bc4d4674bf74569bfd08c46e0d01013a8c2fa1db00/ry-0.0.97-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:23ce6c80081ee55c03366d7a135762494c0783d904e65d8c38dde9566e47874e", size = 6681371, upload-time = "2026-06-27T05:30:58.476Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/49/118c34929125dc15ef813fd1afa79c0074cfc757f01f419c302a56066e2f/ry-0.0.97-cp313-cp313-manylinux_2_28_armv7l.whl", hash = "sha256:bac43ecbc7ccfff5539c946741ae0c1de1ada44e4d3d44c12d09f73459ff9831", size = 6509972, upload-time = "2026-06-27T05:31:00.327Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/63/e5b50f67c3987f24ddbf093f78e2f50afd9a6a02616936d22a0f3299e42b/ry-0.0.97-cp313-cp313-manylinux_2_28_ppc64le.whl", hash = "sha256:c190163cee6db6b0c073a1f21bacd23bc007d0ceea1eda22461a1d26dca04b44", size = 7119868, upload-time = "2026-06-27T05:31:02.181Z" },
-    { url = "https://files.pythonhosted.org/packages/43/9d/c641863fdf9dfc2e26c45c8359c45458436309a6e07c08dd3810f5d2cc1e/ry-0.0.97-cp313-cp313-manylinux_2_28_s390x.whl", hash = "sha256:41379ec817a1d6ee0cd36f2636ebd14cbb5bf2843b036012db9dc5a5a6844481", size = 6915055, upload-time = "2026-06-27T05:31:04.017Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/d0/5b65cd55abd85ad3a470e5fa1ca0d2752d5a5a900cf6769fb869cffe25cd/ry-0.0.97-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:95c8ade07319abee97653ea168ea367f39275e80b749d3b88493a358473357e8", size = 6811857, upload-time = "2026-06-27T05:31:05.883Z" },
-    { url = "https://files.pythonhosted.org/packages/04/2f/74e79494feae39a398a58fb46480818c5e7f6f519c64c2d7e988f142cebf/ry-0.0.97-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:096c44325326e1525a2d231ea9046cb0f1a31186a2763285ec028eca48c9e114", size = 6636400, upload-time = "2026-06-27T05:31:07.567Z" },
-    { url = "https://files.pythonhosted.org/packages/18/4e/d4bac762b0d711fe082579f6ae1fe33c5bfc44d17a8b11b0464e8cc22691/ry-0.0.97-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6a21c852d8990e83c5999c31fee0280a67f6eaef4b217b5d6664b098bd869cd5", size = 6754717, upload-time = "2026-06-27T05:31:09.591Z" },
-    { url = "https://files.pythonhosted.org/packages/06/10/ecadd5ed74c45b536306f17b5f28d67c2fe7a9582b394962291bbe5f6efe/ry-0.0.97-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8697673114005f9d62464f18f1c2cb67b21430cc107bb62ecd09b3dbbb9aa1b9", size = 7219126, upload-time = "2026-06-27T05:31:11.349Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/af/b40b2012135957e40000b35971a4289526f7300deef471c2f190b9f47f82/ry-0.0.97-cp313-cp313-win32.whl", hash = "sha256:063ee18d45c71cf77e016572a50cf3cb3636f4799231a32073792701f2d561e1", size = 5989318, upload-time = "2026-06-27T05:31:13.319Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/c9/da22d4ace1137d035fb0cddc4129a75e8465c7a4b39b80255e9e3b8bd3bb/ry-0.0.97-cp313-cp313-win_amd64.whl", hash = "sha256:8dc94ddea705f5aaa4854c89a0baae2a6fba377b1b777288314e3fdffd96002d", size = 6330487, upload-time = "2026-06-27T05:31:15.131Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/c0/24347c6e968c8d35099dafa4f4a4fd5525ccee625252fc8dc4484a1f5a6f/ry-0.0.97-cp313-cp313-win_arm64.whl", hash = "sha256:c8bacd2b88a3a3599ed1b61c94f7c2d19913062c15801a40827e7b222f297bfa", size = 6243220, upload-time = "2026-06-27T05:31:17.703Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/7a/f74739f98a66397a0851dd7087f78154bef4b58d2fd7d6486c748cac5df3/ry-0.0.97-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8c1180b01b590c8a743105611fa88cad9faa3a5eff9f9738fd27b736f0b57b77", size = 6232149, upload-time = "2026-06-27T05:31:19.644Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/ef/c763c2016134f324c8848aa9c2582af63107414c8d5dd36ad747c7e04d9a/ry-0.0.97-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:325265ed5e8ae63b3e9831d3809c9592b92061576c775d849d8047b1a68462d2", size = 6829942, upload-time = "2026-06-27T05:31:21.666Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/a9/a3e56e151ebfe789515b312ca1cee209c35a2431c4fb26023597d7d40bec/ry-0.0.97-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:139ac2bf0c58e6c1d515d5fd2ab4610a2ffcbb0e773a563e5cd75941a26c7a9b", size = 7048188, upload-time = "2026-06-27T05:31:23.928Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/52/4789aadabcb049fc0fe696e808ee27f7d2d4342d8bb1bf8e23a22083d37a/ry-0.0.97-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:7c99169b7973a91405701a17d068ab4675e78dc0f9ecf51dd1fdfecdf7099ffe", size = 6684722, upload-time = "2026-06-27T05:31:25.847Z" },
-    { url = "https://files.pythonhosted.org/packages/58/70/eddb165885eb6cd2ab3aa772a443d410821dbc1172fa660c72dd6d4f7a57/ry-0.0.97-cp314-cp314-manylinux_2_28_armv7l.whl", hash = "sha256:20ea47e5a7827b5643774789390b0979dd918b3e3157e4e6de5469d95b5b91b9", size = 6509459, upload-time = "2026-06-27T05:31:27.698Z" },
-    { url = "https://files.pythonhosted.org/packages/74/55/089d0fb378479da752bf0fa14a8784297bd35b191feb02878ff04bd16527/ry-0.0.97-cp314-cp314-manylinux_2_28_ppc64le.whl", hash = "sha256:ac772566f812abc35199001333451204666b7a2ec6555be1045e42c474779e04", size = 7144356, upload-time = "2026-06-27T05:31:29.519Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/fb/1d2b3490f29934fc31f5e2c12f3a159f80c71f66fe034cb4c6809d9e6723/ry-0.0.97-cp314-cp314-manylinux_2_28_s390x.whl", hash = "sha256:6fcbd358d3c3e4d2fd40a371b0622653ea249d5abdbb83f01712d9f2ef862784", size = 6933704, upload-time = "2026-06-27T05:31:31.458Z" },
-    { url = "https://files.pythonhosted.org/packages/de/ae/dd8588dd392e5d1f3cc7f8107e05a99caa1ce383e0cfd67f468511adc631/ry-0.0.97-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f06a4a23f1df8faa36df308e46cd780f5d7a52f937e7e379672442f3831b51b1", size = 6814988, upload-time = "2026-06-27T05:31:33.159Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/00/d388023b894393605fe24f36a44980b4fe2e2b7ba2868c7b3b4cb7ccc57e/ry-0.0.97-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:87b56130ae2df99ea7026432d5840aafaf74809de1ba05672c5c1d6d1d05e3b7", size = 6636698, upload-time = "2026-06-27T05:31:35.023Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/eb/c412f9c4e90853482099d9aaa2407c8d0dd63563e201f1f1c3500eadd2dd/ry-0.0.97-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f59acb0f517975fdf80db2069301341cb9277c26168962007b601b0171abfe51", size = 6751316, upload-time = "2026-06-27T05:31:36.89Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/6d/b0cdedf1e51b6c9ebbeb9cb2cfb084d28d362cbc6e5e966224a4066dd080/ry-0.0.97-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5df11d2f29e79bcc5469b387f9a026a461eccdf64bac5ae17fb5d7a145b0887d", size = 7227052, upload-time = "2026-06-27T05:31:39.037Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/83/9f1bf0018a8359bb174def1bdd9193421dd4aa6839c6b5ff3015bf6b22ff/ry-0.0.97-cp314-cp314-win32.whl", hash = "sha256:8b65d625ef25153f3fc982f533eab6c520be1ca1221b5826ace115facb43264c", size = 5967642, upload-time = "2026-06-27T05:31:40.887Z" },
-    { url = "https://files.pythonhosted.org/packages/56/b9/2f0ea4261f5a3f87dd90a70e272cb9f4cbee754c3626a7f57ee70d8357b8/ry-0.0.97-cp314-cp314-win_amd64.whl", hash = "sha256:90b6c454d42e64be99c8a99ee1966c0593bc6d8d847f58007cb3901ee51917ca", size = 6316531, upload-time = "2026-06-27T05:31:42.791Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/cd/3ce89dfcb408325c7c87ddffbf838acca70cfd9064a271b3406b44916986/ry-0.0.97-cp314-cp314-win_arm64.whl", hash = "sha256:dd0ea6ba9089272c78732ebf7beff41c0c4a2378dd02a28d8584030fe24951bd", size = 6230130, upload-time = "2026-06-27T05:31:44.651Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/76/ca3b35b41305fac4c1a1158f35c39ac3ffcb8a9e4921c56ee6052ebd4893/ry-0.0.97-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:dd35333d464f957f14bd5a1b863cc7cacb1428c8fed8a9c7edabae43109b9cee", size = 6202167, upload-time = "2026-06-27T05:31:46.285Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/74/849b9ea03d9e020b03a35df8555df1e0efdf7e81fa6afc4f3113291efff8/ry-0.0.97-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:870c4ce108e0e75247190c55d05c1bc95c0cb9df2605e24335dbcdd0886ce979", size = 6790014, upload-time = "2026-06-27T05:31:47.948Z" },
-    { url = "https://files.pythonhosted.org/packages/64/b0/064a468c9c178fc579cdebef8c882937e8137bb70123d04b109db2fa5668/ry-0.0.97-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5b30805ac23f77b84c3b51ade3256513c040aafc725c325f2feca12882ad6e66", size = 7014516, upload-time = "2026-06-27T05:31:50.249Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/74/535d100c1fc5f933702f2156e4fcddd3c8397ac93d403d12259d9fb01191/ry-0.0.97-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:61045cf3561ea0f705b88ba554c7a39090c3b841c4c5ad2010c68f5c430c804f", size = 6648615, upload-time = "2026-06-27T05:31:52.08Z" },
-    { url = "https://files.pythonhosted.org/packages/66/7a/6c123780d4ae50fe194170df398fc163c1a09bc6f4872d980dd4ea143cdd/ry-0.0.97-cp314-cp314t-manylinux_2_28_armv7l.whl", hash = "sha256:e9887dca5ccb3ad93fd8164d0e978212d7a541909846ad0698efa2e5e971e8a9", size = 6471066, upload-time = "2026-06-27T05:31:53.979Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/78/18a14661738d503e28adcd8c495f81f59c5d07f2c7940d7d8d060c0f15ff/ry-0.0.97-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:e2c5d33d38a5832b91864f85ad17181ec64b3b46b6395845649b2b6c6ee8ebdc", size = 7106413, upload-time = "2026-06-27T05:31:55.99Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/18/9f8ebbee760d5628cd20d652591c848b550655bf578f2b45c902bd6ec0ca/ry-0.0.97-cp314-cp314t-manylinux_2_28_s390x.whl", hash = "sha256:7ac11e03563b62719d46592a8e4c30cfbc2122de018febc2d576f20a7fc6c0dc", size = 6897636, upload-time = "2026-06-27T05:31:57.769Z" },
-    { url = "https://files.pythonhosted.org/packages/99/3d/fa64b8ae1884bcf8ea8c0fba7e45c9d48412535a0f64fac4ca0504d2dcad/ry-0.0.97-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f53e5c51e415d380640f5caa596265ed83c1529f08d2cd7cc4a20bb0df9a1b15", size = 6778745, upload-time = "2026-06-27T05:31:59.63Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/33/d2901e94a6d9b5e8bdbcaa4b1cdcdb425d65d5659af2bf188396b9d9a36c/ry-0.0.97-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:2afb00673f7a64c6cdfa740f4373befbdfe60d2b9da203fdee9a4efca2eccf13", size = 6595196, upload-time = "2026-06-27T05:32:01.476Z" },
-    { url = "https://files.pythonhosted.org/packages/75/5e/e4670d39be4b1b26791c081b49a7a7ba268d4b8d23402881f7a8c0427b0d/ry-0.0.97-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:7d546844b8b91257e8e98b00b6812c108d3c636109668a95a9807816e80cc9db", size = 6716255, upload-time = "2026-06-27T05:32:03.602Z" },
-    { url = "https://files.pythonhosted.org/packages/50/23/5ee95a73f01c86d80ac3645091fbf279958cc3b6cc3caea0f5c7b90f61c0/ry-0.0.97-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:df2f0d259f3b298529534f88642272f8bb65aaa8fa965f50d9ae7c6b132bac01", size = 7189718, upload-time = "2026-06-27T05:32:05.54Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/5e/4df6dd165d9cc0985399828b828e31e9aacbeeb0c16fcb0a87457f52b19c/ry-0.0.97-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:200aaa9fe8e4bf652cec17a3fd56494e2488b22eb72c409bd3d207f83f5e8d9c", size = 6362625, upload-time = "2026-06-27T05:32:07.34Z" },
-    { url = "https://files.pythonhosted.org/packages/54/4a/0525150e282eff9c54098d27aa0e40c379f3c348a45e458e4de67770d83f/ry-0.0.97-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d96afe4b0bab322da798cc0d02d450e19100db3d3fefcfa0f5e1b5f48851db20", size = 6938410, upload-time = "2026-06-27T05:32:09.184Z" },
-    { url = "https://files.pythonhosted.org/packages/29/9d/c599b1cd1065cecbf9b13660b69376112faa6a54aeb1d407188d708f7a99/ry-0.0.97-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d58efce169fb0a5e10db97fc62868cc565e1eb279bf8208d312ef1b6054984a", size = 7086074, upload-time = "2026-06-27T05:32:11.075Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/9d/5af3a8b22e74c6858708fdb3e8b90398d2ad420f078dbdd29d9840f33594/ry-0.0.97-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:f2373b1d018004aa9a1ad706f0a0a63f0e7ad54b0a146b9ba3a511df079bd9c4", size = 6737405, upload-time = "2026-06-27T05:32:13.364Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/5d/1f5df4b8f79cf09e578467963fb7263a1b06614544cde7ea1f04691c484c/ry-0.0.97-pp311-pypy311_pp73-manylinux_2_28_armv7l.whl", hash = "sha256:9dbf545e27a9b66ee5cbc7a21a13695f1503f4ba5f0d70a244eede9574d32f89", size = 6578061, upload-time = "2026-06-27T05:32:15.099Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/2d/41b295c50492eb5fbdb277bf4cfbdb20c16e6f153cf380084a6737974770/ry-0.0.97-pp311-pypy311_pp73-manylinux_2_28_ppc64le.whl", hash = "sha256:bb460255aa6a875ce65ef08bebb12d5a2cb6e73c03108e2faae311a64c8962f8", size = 7223118, upload-time = "2026-06-27T05:32:16.947Z" },
-    { url = "https://files.pythonhosted.org/packages/73/22/48a0029142dadde19f6def6ac2c8b17ba5094a0f109cfaf3ecea5d76755f/ry-0.0.97-pp311-pypy311_pp73-manylinux_2_28_s390x.whl", hash = "sha256:c2cacbabcc4e0492f35321fbcad49238f8d09298c375b92e37eb162736d6c551", size = 6990834, upload-time = "2026-06-27T05:32:18.925Z" },
-    { url = "https://files.pythonhosted.org/packages/08/e9/121db313d80dd63d50846cac421b59fd0eee5bca1fb9546a7e1575a8b9a7/ry-0.0.97-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:c70b86e3ddbb59644bb5741677c86e5fe8ac023d2a2d45143fde9a9e46eaac84", size = 6869334, upload-time = "2026-06-27T05:32:21.12Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/53/61d591bf8e9785b8f77a9eeaf3bba45593bc1e8d1c8f27790beaa9e7c5b7/ry-0.0.97-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:3d3ef7f1ed06b485c45be190460356b0255f1bba82cfecf63e98b6f2ce64a514", size = 6707559, upload-time = "2026-06-27T05:32:23.023Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/67/89553913540e29c4a3a2d48ec34904ddd9e570a2361091ffb4ba3e825cfc/ry-0.0.97-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:aea3fab17f9be1a2e7b910e967233ce70232bd8b45f026707f7add8cc967c89f", size = 6856284, upload-time = "2026-06-27T05:32:24.957Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/c6/1b73f1fe5eda5981a76032e3528b7b03a3b5475719f28f53cfdbf08357ba/ry-0.0.97-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:40489f1f0f5d8cdfa6e8ef2ba49665775e02fb991fe3d105ba95291ab2f86ce5", size = 7263120, upload-time = "2026-06-27T05:32:27.983Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/78/9f805ce2f2843bff382046dab48787a44eb287f9f8340f05d7faa3fcb849/ry-0.0.98-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cba778a3d27a87bfde0912e5a1e30e4c145eb720e281e705c54874acd2413d8d", size = 6291698, upload-time = "2026-07-17T00:48:17.419Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/90/e5b51551f9fc74eb6402d1efaafddeaee8d99737304b6a295409b0b6657e/ry-0.0.98-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:36f6d30578a1a5fceb76ece592b3d769c59bbe5de81edc6cdd8c4338917f86bb", size = 6923684, upload-time = "2026-07-17T00:48:20.297Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/74/e60a1677b9a20af3da2a9036a16eff0a2d2f583d7275b0c588e6f312e48b/ry-0.0.98-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:93a8c00aea26d8752b870d598661229fcff16c1a0561e0f50809a94ae3aa6218", size = 7073362, upload-time = "2026-07-17T00:48:22.436Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/06/1cc234667211b0067ba0526d0f751434a633a1c8eaa35de5081e0bc00d2d/ry-0.0.98-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:4e9370f6cdbef481943780518df997f0de37f74fb00470666f13b352a734c719", size = 6730325, upload-time = "2026-07-17T00:48:24.995Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b9/3596910420022fa7b326643e97345928c537385263ac353968a24e26d9a7/ry-0.0.98-cp311-cp311-manylinux_2_28_armv7l.whl", hash = "sha256:e1f27ca1f5283f26f9ac2dc150421a8b4792f89f3158c158445e0ee8e14644f1", size = 6570444, upload-time = "2026-07-17T00:48:27.034Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/81/f6cd6af49ca1ab16c6d7c6b5da0cdb5821602a148638f008520c1977399f/ry-0.0.98-cp311-cp311-manylinux_2_28_ppc64le.whl", hash = "sha256:808c0707d86ec710ede1a26026a53b34f8f7187f74ae4519994c4fecb21d73ed", size = 7229206, upload-time = "2026-07-17T00:48:30.06Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/88/b518dc3e9780f5744dc1117c1f0c007d77306feb0b42563bd951638146b3/ry-0.0.98-cp311-cp311-manylinux_2_28_s390x.whl", hash = "sha256:9ddd7f104fec50398cfcc2f70e25b7f67600763a41519b2d23916e95db573053", size = 7004075, upload-time = "2026-07-17T00:48:32.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a7/0382a87f799228898717713af9d69a5979e42421d7c65fff51fd56ae7b2a/ry-0.0.98-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2c19309a3ae931727c5531685d16ac91e9482adb0e1019890ce218653e0b544d", size = 6862239, upload-time = "2026-07-17T00:48:34.327Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/8d/449bae89e155a6ffc77a7412b62b18ac896780556a4444ee2c20dd9475c6/ry-0.0.98-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:45dd872184e4e36ec4046bca4c33040355a0b89583b23753637f0629b575b0c4", size = 6696205, upload-time = "2026-07-17T00:48:36.81Z" },
+    { url = "https://files.pythonhosted.org/packages/46/22/3221fd8c1ce7d8ad1ac7306318e6026998fb626b42a345a7eed74a3354b9/ry-0.0.98-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d06aa04c10b12c1b37d745b0de72206c26008370adb0e40e50bf71b66293619", size = 6837684, upload-time = "2026-07-17T00:48:38.936Z" },
+    { url = "https://files.pythonhosted.org/packages/29/be/291866565afb1bf4f305c48c0dc90d3cf5078f456d1c1700a49a1354bdf2/ry-0.0.98-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:360d87d66a1a772b0746b11a42e98625409c42f0e304561594b5658c2a0dd81d", size = 7250486, upload-time = "2026-07-17T00:48:41.077Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c5/01c8c3419dbb5ed77417b56e4d75977e4e03bfd16e29b75cfbd5b3547057/ry-0.0.98-cp311-cp311-win32.whl", hash = "sha256:675da14800f04c085b706cc196d949b0513a98c6787db8cc0c35a14fc8d0a5a0", size = 6031361, upload-time = "2026-07-17T00:48:43.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8f/87a68ec07000691d59fb4fcab2ed0d98b605f5d8b543ff68f6652685ea0d/ry-0.0.98-cp311-cp311-win_amd64.whl", hash = "sha256:985f657f36159fd38d5f57559131c1a90195ab6fc0ac133ddfe9d81d25db2f8f", size = 6360466, upload-time = "2026-07-17T00:48:45.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b0/65031776a6819d9a8df9527fefcb70b0a8488b89a6255c72d14887cc0122/ry-0.0.98-cp311-cp311-win_arm64.whl", hash = "sha256:1064d7c03a912580fbe749e0e7bcc05e375953c5fce02b57744ddb83ce0cd6a3", size = 6240445, upload-time = "2026-07-17T00:48:47.344Z" },
+    { url = "https://files.pythonhosted.org/packages/52/75/759ceaaf85f0ac935dceadab92203c7ab7b23c6f8275666c32790be565ad/ry-0.0.98-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86bfb9d2285dca87c25e9ff5a623fabba8de6e6a48f125b6664b1fb69c1529aa", size = 6240508, upload-time = "2026-07-17T00:48:49.343Z" },
+    { url = "https://files.pythonhosted.org/packages/43/b5/992375e2de8c1c4b160a204b2b91d33522bfb894cb5b8f2c22b05a1f5b80/ry-0.0.98-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6167f468629f9ec8ad3e25965895f9dd5de72a19dbfb00d9469c9903381e6027", size = 6896151, upload-time = "2026-07-17T00:48:51.581Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/65/bade19d74c0f31dbd0b13bdb266e1498f4cbb1debacf2ace3284c0206ac8/ry-0.0.98-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b09fa1108160b4f422b2ff1ad9d4b0f499c5528b26b3f6ca09408bbc53a0bfbd", size = 7081918, upload-time = "2026-07-17T00:48:54.661Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ac/d52a28b9d8876a8a32b6dcfe10c3197fe512be92a2b66001f7770698828e/ry-0.0.98-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8181db6cbbb33820d099e3ee823818cc211eea8df6eb767be1cdcbf4c1e99b57", size = 6732115, upload-time = "2026-07-17T00:48:57.102Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/c9/818e856dd33521c6ef891e580c5c2aafa37f3464c4887cb59e93b1f498c5/ry-0.0.98-cp312-cp312-manylinux_2_28_armv7l.whl", hash = "sha256:49737e5ea9f815fe481f18c92f8a6e9190d4a02524361cd76b7b6ac946333882", size = 6577937, upload-time = "2026-07-17T00:48:59.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/575c3b579723cf9355e57e1d02b0afdec55ead52f05d7fe3adfc5b26cfd0/ry-0.0.98-cp312-cp312-manylinux_2_28_ppc64le.whl", hash = "sha256:f01353269dfa4668065b7f620fb3ffd5d3290e5ff7e7e132d0af6ef329a4d6a0", size = 7188075, upload-time = "2026-07-17T00:49:01.498Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3e/63d61fa27f56fb705f15454d6c88906bfd1eca55abf5d1d37193ad4e676b/ry-0.0.98-cp312-cp312-manylinux_2_28_s390x.whl", hash = "sha256:aaa78b5d0df520c5138b6c0956be2b03d908b8a04bc090b16b812368cd1accbe", size = 6986483, upload-time = "2026-07-17T00:49:03.625Z" },
+    { url = "https://files.pythonhosted.org/packages/66/10/dbe54b71b29f84e1835bd6e270a724eeb7fe2a5ec1f8b1c68df3a5e74f48/ry-0.0.98-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d3a97d242dd84f60abfd7dab877dd01483d82d4a534a00d89a8e3506daf48a8b", size = 6862150, upload-time = "2026-07-17T00:49:05.733Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/33/5219cbc34207f47066eb7922bce73f82fdc35fc33d69c2073cec049d7525/ry-0.0.98-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b65890a50545b4abb5c80c98297890ded88b62679b1148a6b9f861f9c19cc6fe", size = 6701517, upload-time = "2026-07-17T00:49:07.866Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/38/3ceff94e58454914f15be045ace9e2b1f33a75cc4ff3f3cce101d2d86d5a/ry-0.0.98-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c762b87d2f3f48c5dc33df48e16aa10bb2bcdbde8a2b5bc891ed7002ace930b4", size = 6809046, upload-time = "2026-07-17T00:49:10.138Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f2/3d4348a03ec3624918b6d85dd4599625aac41a8b682520c4554dbf189e17/ry-0.0.98-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:02bf7a8c2a4eb22fa382835bd4ebd1777940cfd3cf23e585774d6ddb3fe74567", size = 7260712, upload-time = "2026-07-17T00:49:12.226Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ee/d4a3aab189463ffef0b1c8675e6d07a7f2b719f523496dd2b2ce9e0d753c/ry-0.0.98-cp312-cp312-win32.whl", hash = "sha256:8adf4a53a6e5825ca8011379316f7865122076e90985131544c7450403b3ca71", size = 6043005, upload-time = "2026-07-17T00:49:14.246Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d3/7fa39200d84d43ff7498645c3580e0c650fec2283fcf19031e70483ac8b3/ry-0.0.98-cp312-cp312-win_amd64.whl", hash = "sha256:94d4234a2e064cab13f909cc0e1c960d3d3b4671d3203bbd0a3b5848e8f3de1a", size = 6375190, upload-time = "2026-07-17T00:49:16.619Z" },
+    { url = "https://files.pythonhosted.org/packages/55/2e/c0140b08fd9965087fcba2bcd9c4dfd2eb69689229a39ba28f8445d73866/ry-0.0.98-cp312-cp312-win_arm64.whl", hash = "sha256:7cf8cff117c46d02005b7460cd3991cfde52f7efa0a0a3fb02a80076de697b10", size = 6245820, upload-time = "2026-07-17T00:49:18.651Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/e385b2bc9af496830b31bb3c29e5768a819a1df44094f0330f1be79a2954/ry-0.0.98-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0ffea0f42eab12fd920c690a78b9aa3f81097d04097aa3c063e6416699911738", size = 6241359, upload-time = "2026-07-17T00:49:20.738Z" },
+    { url = "https://files.pythonhosted.org/packages/50/37/6e6afce33c012f9a93f8f867c4dafd4b3fdd8a97ded2c51883db16b480e9/ry-0.0.98-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5e31ea69e5618ac6c784e945b3d626a7289b405ab18051bfaffa5c5171f60a15", size = 6895723, upload-time = "2026-07-17T00:49:22.946Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/9b45fa51c595ce69c6f8aba7352d2d5d6e1711b4d3632a77cdff0809f23f/ry-0.0.98-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:103e00521f4d7ac50349dbd567417e7b6cbbcc43d5f31184221a25b1f9138fce", size = 7083461, upload-time = "2026-07-17T00:49:25.344Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d2/abe6ad73721ed8375f4cc891be17403081067915d745d4d984ac8dbae471/ry-0.0.98-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:da5dedcff0e39388483f913a941304a5dc2f83f1d4b4ff38dd5146d9320614e5", size = 6732358, upload-time = "2026-07-17T00:49:27.405Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/61/7effe7b2222bdf0a70193466fb500756663603e19aa4fc083755f08f611b/ry-0.0.98-cp313-cp313-manylinux_2_28_armv7l.whl", hash = "sha256:4f4761eaf4b5ddd4aded11147249971c488c7d771f4ff7d7a682b98f332231ae", size = 6576082, upload-time = "2026-07-17T00:49:29.273Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4c/ebfd1f9c8f8807a39bf92d6e68887a85b4ad61f93ebbf39ef47bcf29c17c/ry-0.0.98-cp313-cp313-manylinux_2_28_ppc64le.whl", hash = "sha256:e5d6e3361ddadb81991362fd54cb869cb2a4b2a07f6fdfeca0c9594347a8bbba", size = 7189013, upload-time = "2026-07-17T00:49:31.481Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0a/2c32f4f8a90ff6fb02edf785c45ea9da48505b9cb7808e106988c223623a/ry-0.0.98-cp313-cp313-manylinux_2_28_s390x.whl", hash = "sha256:24c46d651ea02611dd7c029c31bf24556e9286b9b925b22faad5edef756a3620", size = 6987118, upload-time = "2026-07-17T00:49:33.557Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/6d/51bb2260cc7809ea6b8efc4ac7b88c24243deda50c49d57890b888b680f3/ry-0.0.98-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8228d8dcafb5a82f082b75bf7be7affcf485f41e5f3a015a04aec4cba01cb726", size = 6863828, upload-time = "2026-07-17T00:49:35.568Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/e8/66037b38b94d64f59796f3078c96e74e1264b376a50f110ae73c966e6c24/ry-0.0.98-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d0ce5241ff7c9ace3744d462fb7deb0813b4754396911ada693cb0e537ca2ba5", size = 6700611, upload-time = "2026-07-17T00:49:37.805Z" },
+    { url = "https://files.pythonhosted.org/packages/05/5a/4de99b999fef78e6a2da84cf9085200ceeae31b979e0b0bb11380e78966c/ry-0.0.98-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7b17eed4899adf7b67d98ff5a5733b844a9d20038492200355348689728e2e60", size = 6808387, upload-time = "2026-07-17T00:49:40.09Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/69/ecddfb520365f9bdf19bea82991e569ee02b916e6ffb071673a3ae253f78/ry-0.0.98-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ae3fd6f26cdf8597c7c70e9205329dd0a765178a881bccee62850ffa233afecf", size = 7261563, upload-time = "2026-07-17T00:49:42.248Z" },
+    { url = "https://files.pythonhosted.org/packages/95/19/86561d24dec8a2e828c88936ab64a1ca69fe5c605de43ccdd5381dac289a/ry-0.0.98-cp313-cp313-win32.whl", hash = "sha256:0b136b9a2d2a7eaf38f81f390d7680366ce4d358462aaaeb986e96cf0643d61b", size = 6042745, upload-time = "2026-07-17T00:49:44.556Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/49/9e63208e825d31f7cef53f72c302b41d693b06bf6973e10705b48ddd7769/ry-0.0.98-cp313-cp313-win_amd64.whl", hash = "sha256:cb9b67daf60f9e901e2263b8afaf74175dae455febfac8e25a080952b7cc073e", size = 6376094, upload-time = "2026-07-17T00:49:46.801Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/6e/c545d733b5da35c13aa4d1da2bda715fc25b9f55f3c763f0e4378481f342/ry-0.0.98-cp313-cp313-win_arm64.whl", hash = "sha256:5a4ab7ec59835ac1ea80191cb33adf26cdac33eaa30ade11bcc1b7252f507973", size = 6245905, upload-time = "2026-07-17T00:49:49.119Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/da/5f428b6ae54b68c5d416b68456f72dac87df4159a80eca4e688a22d7677f/ry-0.0.98-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:73cfe93652d0b5e7f85d5eb7deaa4c3eaf55ab297dd089a363314fd62668bdad", size = 6232154, upload-time = "2026-07-17T00:49:51.29Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ff/14b928b28f313c1b4b8401895c73c394a5ec163ca57c85629552ef34d5e4/ry-0.0.98-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c8d95bbe60ec5d2016f68e7be5668761acbacc8cd12d3f23cc856c697618bcc2", size = 6888135, upload-time = "2026-07-17T00:49:53.246Z" },
+    { url = "https://files.pythonhosted.org/packages/50/61/d68da2359d7a7fc95a07c24d4d6feac8b055186943751e88d99da12cf7cb/ry-0.0.98-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:23a76e92c7e8dd748ae775d4c9aa0b2c0f8b59316c931835b51e8ab7ea34b119", size = 7089366, upload-time = "2026-07-17T00:49:55.671Z" },
+    { url = "https://files.pythonhosted.org/packages/21/c1/dbf882d08f13535fc69f979798c0587cbcf8f4a349916e621e9b13b7da26/ry-0.0.98-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:17869c6614ad3ecb3548ec57dfa1a0db724369b264ec7fabde3c3ffc5bf1980c", size = 6738137, upload-time = "2026-07-17T00:49:58.249Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f1/3d096164ee7f0606825fc26fa61408928db49ea95ec9d750a785f8e06ffe/ry-0.0.98-cp314-cp314-manylinux_2_28_armv7l.whl", hash = "sha256:5a6c4ee277b113f5f03b9ae6bd8621e5f5e5c8e9aa99559d209fa874c15e8fb7", size = 6575770, upload-time = "2026-07-17T00:50:00.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/3c/0951c497fcf46ba6631eb3e303d126edc07a9b15e147421f51bfb457d07c/ry-0.0.98-cp314-cp314-manylinux_2_28_ppc64le.whl", hash = "sha256:a89915aabd8740ace6f7697bd4d9c679d4c1fdd33f35fac579b13f09e5042cdf", size = 7210568, upload-time = "2026-07-17T00:50:02.812Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/72/450de5305f27c9d42e742a3cd5cc1142fdde37fecaa8977940f6cb32039f/ry-0.0.98-cp314-cp314-manylinux_2_28_s390x.whl", hash = "sha256:bd45a6e4a209b4eb800640a11252722ce2edcd85c46e6a8eadb252e24869b008", size = 7001197, upload-time = "2026-07-17T00:50:04.891Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/63/d9762ffeec2c5fefef02ff0d121bbbbc7978af62aec31167d3a4151e7246/ry-0.0.98-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ed391ec1d9035042b8760f130fce2471d55a95d7562b874ad551a84fe5b11911", size = 6867201, upload-time = "2026-07-17T00:50:08.112Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2b/a5e870e251e69f7273fe636ca13040e30a2f330f6a9d6df44f2ea71df6fe/ry-0.0.98-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:9cae7566580237780d9bd5c2155b00be2efede13fdbc875400c168262ff98564", size = 6703092, upload-time = "2026-07-17T00:50:10.136Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/9b/90a4db8cfa2c17d1714424d16a3d67e15aee89bdf57d8ebf385289dd71b3/ry-0.0.98-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f78063720a941cc5886e4dd8a489d4ea2f8d83d3104748690abe6af304f932d6", size = 6805573, upload-time = "2026-07-17T00:50:12.389Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/49/979a8147fd3c2f1b8a96a6fd7effde2ad2fdf953930516924c966608633b/ry-0.0.98-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:11a51254bf77f9b39b75c57b91af9a719b5df673829d42bc3adce295cd9779b2", size = 7269208, upload-time = "2026-07-17T00:50:14.711Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5c/6c184a938f85a2f5879e1d6ff0035e22ad0d8017349518b8d3084f74a220/ry-0.0.98-cp314-cp314-win32.whl", hash = "sha256:9f459f580e4f124dd0461694dbb02f6b338cc0883a6349dc2fe2b53e70eaed6a", size = 6020034, upload-time = "2026-07-17T00:50:16.566Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/03/bfc2bfa14c97642a0179fe2203c0fe0dc83db8e9d68a733f13f60f43e663/ry-0.0.98-cp314-cp314-win_amd64.whl", hash = "sha256:b57fa1bec22950eda42eaf051a8a28c5a3aef3cf4137a5b096808ce7af5cc517", size = 6358739, upload-time = "2026-07-17T00:50:18.635Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/ae/52fae8ba0c76864d839c8960aa8901723edfd2d49a9628f30a030e2a9584/ry-0.0.98-cp314-cp314-win_arm64.whl", hash = "sha256:4d91b93e2320c1f5360061de4df1e2fc24f9aa3fa6d129bddb86bf8d4c462789", size = 6229049, upload-time = "2026-07-17T00:50:21.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ab/59920ed56c2d4ac71ea90bf4388af2122ac436d4399994c6b9ade7ba208e/ry-0.0.98-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d7264d833c67d53b7875985ba3bb531a2dbdcae003c7e16874ade26bacd0382c", size = 6202396, upload-time = "2026-07-17T00:50:23.073Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/d9/7797688d3ece826a23ffaaf3b0ff9ef1f86aee9bd25b6881a8a882257345/ry-0.0.98-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5637193d5b960142d6dc4bee65aa43b982e874a202e86d2ef1d48c9c6054cadb", size = 6848792, upload-time = "2026-07-17T00:50:25.194Z" },
+    { url = "https://files.pythonhosted.org/packages/89/d8/d942b2968921acbbcfc882e5071b342675105e4fb6acfa6499cbadbc939b/ry-0.0.98-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15e35b897ef3f4bb3b01319b6271a71c59eeb5c637b5c50bd7d19ecde0f19a0", size = 7056972, upload-time = "2026-07-17T00:50:28.26Z" },
+    { url = "https://files.pythonhosted.org/packages/df/1d/5bc41748566b5095d78c6c32a1794db353ebb70c4cdc22d56d008fd5ba67/ry-0.0.98-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d20650ae210ab78b317004fbca65c0506a30cb701ed6ebca467691f67a3efd46", size = 6699796, upload-time = "2026-07-17T00:50:30.308Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e4/bc6d09e28150e16cc2eff4e23e0f311646593b06a82964d4658daabf58ee/ry-0.0.98-cp314-cp314t-manylinux_2_28_armv7l.whl", hash = "sha256:008ee846db3bc8d6e3154f131c0c02fc75e62538aaf00b10b6f9e171e3986730", size = 6538187, upload-time = "2026-07-17T00:50:32.543Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7e/9123bd46273c44a6f363f415b513a13ce67d61b7271c573889d204ea0321/ry-0.0.98-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:4a39e7281e6df15e81c16755a8080a6d86af4fd985f0db82d4396a8478fced2a", size = 7172330, upload-time = "2026-07-17T00:50:34.687Z" },
+    { url = "https://files.pythonhosted.org/packages/18/47/40de9c9e446cd5cdf4355af8c910c82847e91f5524af9c1ad9107543e158/ry-0.0.98-cp314-cp314t-manylinux_2_28_s390x.whl", hash = "sha256:034a3ef44f1dba53db274133d7d38e5af557e57f05c231df3e0d3181f9f8e5eb", size = 6965415, upload-time = "2026-07-17T00:50:37.097Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1a/ec6b7962f9f13bb9a202f27d18bfa6cfc444418d14079eb2794ca6d70868/ry-0.0.98-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3d19b3e36ad1f5eb64ab1eee69dc5e282af3333db5368bd0f6f3114ec8298b46", size = 6831130, upload-time = "2026-07-17T00:50:39.279Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2e/f0283f00245086fc2c47d8eaef0dc71caf414873fbf926614d70bf435a6f/ry-0.0.98-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:0d794a664f2dd3ad0e1f9b22db40b04a34789c3f9758bf6f78e447dcb706f6dd", size = 6661934, upload-time = "2026-07-17T00:50:41.833Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/31/492345e38e5a3f870ac1e5bec729bbb65e9a7815c9f132c91c15fa606a79/ry-0.0.98-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:923e36b7e65afb12a0bc42a9d0da5a0e0f09636a691163ce3b2147b7e2e2bce6", size = 6766136, upload-time = "2026-07-17T00:50:43.751Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/3a/e19c005225acc11583fc77d79b1483471278f558318a82dd0cc01d01ba04/ry-0.0.98-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:70364a184bc258ea6580752524447baeab0bbb2e8c602aea1d9ac7448419bc8d", size = 7233244, upload-time = "2026-07-17T00:50:46.118Z" },
+    { url = "https://files.pythonhosted.org/packages/88/bd/bf5c29cbdc7e727d68fe00a7092d545f27458e23bf25956e8a61713eaf88/ry-0.0.98-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:3726eef62d7febf7e8ae3585153b4fdb8e6d3a88c4b6c6e682fe55e9204ed65b", size = 6366770, upload-time = "2026-07-17T00:50:48.212Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/1d/a4258aade60d2c5b038bf8e06a0f7e05d66b9e7c206f9132c38db2aa8ad5/ry-0.0.98-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:966370c2122cce8f2c4ba5984b0824bdcf73654412a6d0ba32a1d0da76939f44", size = 6996470, upload-time = "2026-07-17T00:50:50.438Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a9/3d237a5afaa9f77fa375362f43d710c146cdfde66c0fb86df51400557539/ry-0.0.98-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5323ada0424d6850607a017e33a8caad926361dc4496652f1434f4ae36acbaf1", size = 7133610, upload-time = "2026-07-17T00:50:52.597Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/8a/2d7af3e8af7061cda7c08f18f398e67ead1fa5dd140f06170dcca422d8f1/ry-0.0.98-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:63199c252cb801de16a18f00e827aa0ade69747055ccd432955c576a186bf135", size = 6800955, upload-time = "2026-07-17T00:50:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/22/19/20bf019e05dfaefbcc719208163846bd523f3653f20eed8b1aae5c6965de/ry-0.0.98-pp311-pypy311_pp73-manylinux_2_28_armv7l.whl", hash = "sha256:2f45bf94e45c9a896ef60a1964fbeea0398ce95d3bf18e03fd6be1c83c75de42", size = 6650681, upload-time = "2026-07-17T00:50:56.951Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d4/8eea60c53c368a78b6374af9c9f72ae14e0f9e30b07a5d6e2aa30d19171d/ry-0.0.98-pp311-pypy311_pp73-manylinux_2_28_ppc64le.whl", hash = "sha256:9332bd65cedeb57b330b2aa99808f975ab52b7925197e11db19825caa8ae4c5f", size = 7296668, upload-time = "2026-07-17T00:50:59.336Z" },
+    { url = "https://files.pythonhosted.org/packages/98/5d/0da792c57e8a228ced101820f069a601d797b121e7fcdf2a83ca353cfbf4/ry-0.0.98-pp311-pypy311_pp73-manylinux_2_28_s390x.whl", hash = "sha256:dbff7cab22ee0b9aa3933578a90d9648fe7e6d78b43d78f1be33213d2ace65f4", size = 7062392, upload-time = "2026-07-17T00:51:01.896Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/16/2f7ecbbfafa84785485313bae82e081ce30ea4ae7dd6f306d8ba123ed8a8/ry-0.0.98-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:9e3b129fbc2a376b8e12e1fc1274ac04d0a74f45e26473857992120d11cbb7a4", size = 6932778, upload-time = "2026-07-17T00:51:03.987Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f0/eeef17677d4b6fee5aabebac63dce56bfccbd961959304f19e8471f5958e/ry-0.0.98-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:980162a24def3418fd17661059b82987d8ad5ce3ec1480f49b3b84a30c32355c", size = 6776240, upload-time = "2026-07-17T00:51:06.081Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/7f/a3db3efd0b62f4a8b4a8cf14f72a647bd5146bc94c88ac5484e5f5f5b91d/ry-0.0.98-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:5106bc747e70f1128cbf9ce9391d823e303366c45de81ed4bf3f3d436a118e8b", size = 6908110, upload-time = "2026-07-17T00:51:08.514Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/28/7e15e65348be0f17eba49631c1aae4645a20242399744c53075bc417aaf0/ry-0.0.98-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:0fd3d9baabc036932b2d0aa894985b4b9f00217e9a39cc6b847e64a3fae2b245", size = 7312774, upload-time = "2026-07-17T00:51:10.651Z" },
 ]
 
 [[package]]
@@ -2754,11 +2754,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.4"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/38/e12680bbe6b4f8f3d17adcaf38d26850aa756c85cf4a80e79fc12a018fe8/soupsieve-2.9.1.tar.gz", hash = "sha256:c33e6605bbc71dd628b00c632d58ae607c22bade247e52553928f83bbb75b4ba", size = 122261, upload-time = "2026-07-21T16:57:17.452Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/2c/437fe806897c2d6cfdc3ee43a18da8bf8e568530a4ae9bac781541ca9896/soupsieve-2.9.1-py3-none-any.whl", hash = "sha256:4f4477399246b7a0c720a88ca2454b11cd6bb9ae4c9d170140786e916776c14c", size = 37404, upload-time = "2026-07-21T16:57:16.421Z" },
 ]
 
 [[package]]
@@ -2899,7 +2899,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.6.1"
+version = "21.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -2907,9 +2907,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/d9/b477fddb68840b570af8b22afe9b035cbc277b5fb7b33dea390617a8b10f/virtualenv-21.6.1.tar.gz", hash = "sha256:15f978b7cd329f24855ff4a0c4b4899cc7678589f49adbdcbbb4d3232e641128", size = 5526620, upload-time = "2026-07-10T19:33:53.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/25/e367a7229b0914772ca8d81b41fde012d9feda68523b52644a571bb21ce8/virtualenv-21.7.0.tar.gz", hash = "sha256:7f9519b9432ff11b6e1a3e94061664efc2ff99ea21780e3cf4f6bd0a5da8b37c", size = 5527510, upload-time = "2026-07-21T13:12:14.109Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/7c/4e7225d46d634a0d8d534dd8a6ce0c319d09b4d0cf0337eb314ca4789d8c/virtualenv-21.6.1-py3-none-any.whl", hash = "sha256:afe991df855715a2b2f60edfcc0107ef95a79fdfd8cb4cdaa71603d1c12e463b", size = 5506392, upload-time = "2026-07-10T19:33:51.629Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/7a/ae29312b1e88a22e81f5d21fc11526d2a114089776c2550d2b205b6c2a47/virtualenv-21.7.0-py3-none-any.whl", hash = "sha256:a8370c1c5530fbabf955e40b8fbbc68a431648b10f9433faa587db30a06e51dd", size = 5507078, upload-time = "2026-07-21T13:12:12.136Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
```text
Using CPython 3.12.3 interpreter at: /usr/bin/python3
Resolved 136 packages in 507ms
Updated certifi v2026.6.17 -> v2026.7.22
Updated colorlog v6.10.1 -> v6.11.0
Updated filelock v3.30.0 -> v3.32.0
Updated jupytext v1.19.4 -> v1.19.5
Updated mistune v3.3.3 -> v3.3.4
Updated mkdocs-material v9.7.6 -> v9.7.7
Updated platformdirs v4.10.0 -> v4.11.0
Updated python-discovery v1.4.4 -> v1.5.0
Updated ry v0.0.97 -> v0.0.98
Updated soupsieve v2.8.4 -> v2.9.1
Updated virtualenv v21.6.1 -> v21.7.0
```
