### PR TITLE
expand shellfish docs

### DIFF
--- a/docs/libs/shellfish/aios.md
+++ b/docs/libs/shellfish/aios.md
@@ -1,0 +1,1 @@
+::: shellfish.aios

--- a/docs/libs/shellfish/done.md
+++ b/docs/libs/shellfish/done.md
@@ -1,0 +1,1 @@
+::: shellfish.done

--- a/docs/libs/shellfish/dotenv.md
+++ b/docs/libs/shellfish/dotenv.md
@@ -1,0 +1,1 @@
+::: shellfish.dotenv

--- a/docs/libs/shellfish/echo.md
+++ b/docs/libs/shellfish/echo.md
@@ -1,0 +1,1 @@
+::: shellfish.echo

--- a/docs/libs/shellfish/exe.md
+++ b/docs/libs/shellfish/exe.md
@@ -1,0 +1,1 @@
+::: shellfish.exe

--- a/docs/libs/shellfish/fs.md
+++ b/docs/libs/shellfish/fs.md
@@ -1,0 +1,1 @@
+::: shellfish.fs

--- a/docs/libs/shellfish/fs.promises.md
+++ b/docs/libs/shellfish/fs.promises.md
@@ -1,0 +1,1 @@
+::: shellfish.fs.promises

--- a/docs/libs/shellfish/osfs.md
+++ b/docs/libs/shellfish/osfs.md
@@ -1,0 +1,1 @@
+::: shellfish.osfs

--- a/docs/libs/shellfish/process.md
+++ b/docs/libs/shellfish/process.md
@@ -1,0 +1,1 @@
+::: shellfish.process

--- a/docs/libs/shellfish/sh.md
+++ b/docs/libs/shellfish/sh.md
@@ -1,0 +1,1 @@
+::: shellfish.sh

--- a/docs/libs/shellfish/shellfish.api.md
+++ b/docs/libs/shellfish/shellfish.api.md
@@ -1,9 +1,1 @@
-::: shellfish.fs.is_dir
-
 ::: shellfish
-
----
-
-::: shellfish.fs
-
-::: shellfish.sh

--- a/docs/libs/shellfish/sp.md
+++ b/docs/libs/shellfish/sp.md
@@ -1,0 +1,1 @@
+::: shellfish.sp

--- a/docs/libs/shellfish/stdio.md
+++ b/docs/libs/shellfish/stdio.md
@@ -1,0 +1,1 @@
+::: shellfish.stdio

--- a/libs/shellfish/src/shellfish/done.py
+++ b/libs/shellfish/src/shellfish/done.py
@@ -1,3 +1,5 @@
+"""Done ~ completed subprocess results"""
+
 from __future__ import annotations
 
 import signal
@@ -32,33 +34,46 @@ __all__ = (
 
 
 class HrTimeDict(TypedDict):
-    """High resolution time"""
+    """High resolution time as a typed-dict; see [HrTime][shellfish.done.HrTime]"""
 
     secs: int
+    """Whole seconds"""
     nanos: int
+    """Nanoseconds remainder (0 <= nanos < 1_000_000_000)"""
 
 
 class HrTime(_ShellfishBaseModel):
-    """High resolution time"""
+    """High resolution time split into whole seconds and nanoseconds
+
+    Examples:
+        >>> HrTime.from_seconds(1.5)
+        HrTime(secs=1, nanos=500000000)
+        >>> HrTime.from_seconds(1.5).hrdt_dict()
+        {'secs': 1, 'nanos': 500000000}
+
+    """
 
     secs: int = Field(validation_alias=AliasChoices("sec", "secs", "s"))
+    """Whole seconds"""
     nanos: int = Field(validation_alias=AliasChoices("ns", "nsecs", "nanos"))
+    """Nanoseconds remainder (0 <= nanos < 1_000_000_000)"""
 
     @classmethod
     def from_seconds(cls, seconds: float) -> HrTime:
         """Return HrTime object from seconds
 
         Args:
-            seconds (float): number of seconds
+            seconds: number of seconds
 
         Returns:
-            HrTime object
+            HrTime object for the given number of seconds
 
         """
         _sec, _ns = divmod(int(seconds * 1_000_000_000), 1_000_000_000)
         return cls(secs=_sec, nanos=_ns)
 
     def hrdt_dict(self) -> HrTimeDict:
+        """Return this HrTime as a typed-dict"""
         return {
             "secs": self.secs,
             "nanos": self.nanos,
@@ -66,39 +81,64 @@ class HrTime(_ShellfishBaseModel):
 
     @property
     def sec(self) -> int:  # deprecated alias
+        """Deprecated alias for `secs`"""
         return self.secs
 
     @property
     def ns(self) -> int:  # deprecated alias
+        """Deprecated alias for `nanos`"""
         return self.nanos
 
 
 class DoneError(SubprocessError):
-    """Error raised when a process returns a non-zero/ok exit status
+    r"""Error raised when a process returns a non-zero/not-ok exit status
 
-    Attributes:
-        cmd (str): command that was run
-        returncode (int): exit status of the process
-        stdout (str): standard output (stdout) of the process
-        stderr (str): standard error (stderr) of the process
+    Raised by [Done.check][shellfish.done.Done.check].
+
+    Examples:
+        >>> done = Done(
+        ...     args=["sh", "-c", "exit 1"],
+        ...     returncode=1,
+        ...     stdout="",
+        ...     stderr="uh oh\n",
+        ...     ti=0.0,
+        ...     tf=0.1,
+        ...     dt=0.1,
+        ... )
+        >>> try:
+        ...     done.check()
+        ... except DoneError as e:
+        ...     (e.returncode, e.cmd, e.stderr)
+        (1, ['sh', '-c', 'exit 1'], 'uh oh\n')
 
     """
 
     done: Done
+    """The [Done][shellfish.done.Done] object that produced this error"""
     returncode: int
+    """Exit status of the process"""
     stdout: str
+    """Standard output (stdout) of the process"""
     stderr: str
+    """Standard error (stderr) of the process"""
     cmd: list[str]
+    """Command args the process was run with"""
 
     def __init__(self, done: Done) -> None:
+        """Create a DoneError from a `Done` object
+
+        Args:
+            done: Done object with a non-zero/not-ok returncode
+
+        """
         self.returncode = done.returncode
         self.cmd = done.args
         self.stderr = done.stderr
         self.stdout = done.stdout
-        self.cmd = done.args
         self.done = done
 
     def error_msg(self) -> str:
+        """Return the error message string for this error's returncode"""
         if self.returncode and self.returncode < 0:
             try:
                 return f"Command '{self.cmd}' died with {signal.Signals(-self.returncode)!r}."
@@ -113,6 +153,7 @@ class DoneError(SubprocessError):
 
     @property
     def output(self) -> str:
+        """Alias for `stdout`; mirrors `subprocess.CalledProcessError.output`"""
         return self.stdout
 
     @output.setter
@@ -121,17 +162,30 @@ class DoneError(SubprocessError):
 
 
 class DoneDict(TypedDict):
+    """Completed subprocess as a typed-dict; see [Done][shellfish.done.Done]"""
+
     args: list[str]
+    """Command args the process was run with"""
     returncode: int
+    """Exit status of the process"""
     stdout: str
+    """Standard output (stdout) of the process"""
     stderr: str
+    """Standard error (stderr) of the process"""
     ti: float
+    """Time the process started (seconds since epoch)"""
     tf: float
+    """Time the process finished (seconds since epoch)"""
     dt: float
+    """Time the process took to run (seconds; `tf - ti`)"""
     hrdt: HrTimeDict | None
+    """High resolution `dt`, if the runner provided one"""
     stdin: str | None
+    """Standard input (stdin) written to the process, if any"""
     async_proc: bool
+    """True if the process was run asynchronously"""
     verbose: bool
+    """True if stdout/stderr were echoed to the parent process' stdout/stderr"""
 
 
 @lru_cache(maxsize=32)
@@ -156,30 +210,66 @@ def _pfmt_stdio(s: AnyStr) -> AnyStr:
 
 
 class Done(_ShellfishBaseModel):
-    """Completed subprocess"""
+    r"""Completed subprocess
+
+    Returned by [shellfish.sh.do][] (and friends) once a process has finished.
+
+    Examples:
+        >>> done = Done(
+        ...     args=["echo", "hello"],
+        ...     returncode=0,
+        ...     stdout="hello\nworld\n",
+        ...     stderr="",
+        ...     ti=0.0,
+        ...     tf=0.5,
+        ...     dt=0.5,
+        ... )
+        >>> done.returncode
+        0
+        >>> done.lines
+        ['hello', 'world']
+        >>> done.grep("world")
+        ['world']
+        >>> done.check()  # does not raise; returncode is 0
+
+    """
 
     args: list[str]
+    """Command args the process was run with"""
     returncode: int
+    """Exit status of the process"""
     stdout: str
+    """Standard output (stdout) of the process"""
     stderr: str
+    """Standard error (stderr) of the process"""
     ti: float
+    """Time the process started (seconds since epoch)"""
     tf: float
+    """Time the process finished (seconds since epoch)"""
     dt: float
+    """Time the process took to run (seconds; `tf - ti`)"""
     hrdt: HrTime | None = None
+    """High resolution `dt`, if the runner provided one"""
     stdin: str | None = None
+    """Standard input (stdin) written to the process, if any"""
     async_proc: bool = False
+    """True if the process was run asynchronously"""
     dryrun: bool = Field(False)
+    """True if the process was not actually run (dryrun)"""
     verbose: bool = Field(False, exclude=True)
+    """Echo stdout/stderr to the parent process on init; excluded from dumps"""
 
     def __post_init__(self) -> None:
-        """Write the stdout/stdout to sys.stdout/sys.stderr post object init"""
+        """Write stdout/stderr to sys.stdout/sys.stderr post object init"""
         if self.verbose:
             self.sys_print()
 
     def model_post_init(self, _context: Any) -> None:
+        """Pydantic post-init hook; defers to `__post_init__`"""
         self.__post_init__()
 
     def __str__(self) -> str:
+        """Return a multi-line string representation of this Done object"""
         return "\n".join((
             "Done(",
             f"    args={self.args},",
@@ -198,6 +288,7 @@ class Done(_ShellfishBaseModel):
         ))
 
     def __repr__(self) -> str:
+        """Return a single-line string representation of this Done object"""
         return " ".join((
             f"Done(args={self.args},",
             f"returncode={self.returncode},",
@@ -214,18 +305,42 @@ class Done(_ShellfishBaseModel):
         ))
 
     def hrdt_dict(self) -> HrTimeDict:
+        """Return the high resolution run-time as a typed-dict
+
+        Falls back to converting `dt` to [HrTime][shellfish.done.HrTime] when the
+        runner did not provide an `hrdt`.
+        """
         if self.hrdt:
             return self.hrdt.hrdt_dict()
         return HrTime.from_seconds(seconds=self.dt).hrdt_dict()
 
     def stdout_lines(self, *, keepends: bool = False) -> list[str]:
+        """Return stdout split into lines
+
+        Args:
+            keepends: Keep the line-ending characters on each line
+
+        Returns:
+            List of stdout lines
+
+        """
         return self.stdout.splitlines(keepends=keepends)
 
     def stderr_lines(self, *, keepends: bool = False) -> list[str]:
+        """Return stderr split into lines
+
+        Args:
+            keepends: Keep the line-ending characters on each line
+
+        Returns:
+            List of stderr lines
+
+        """
         return self.stderr.splitlines(keepends=keepends)
 
     @property
     def lines(self) -> list[str]:
+        """Stdout split into lines without line-endings"""
         return self.stdout_lines(keepends=False)
 
     def done_dict(self) -> DoneDict:
@@ -245,7 +360,7 @@ class Done(_ShellfishBaseModel):
         )
 
     def _error(self) -> DoneError:
-        """Returns a CalledProcessError object"""
+        """Return a DoneError object for this Done object"""
         return DoneError(done=self)
 
     def check(
@@ -254,8 +369,11 @@ class Done(_ShellfishBaseModel):
     ) -> None:
         """Check returncode and stderr
 
+        Args:
+            ok_code: Return code (or collection of return codes) considered ok
+
         Raises:
-            DoneError: If return code is non-zero and stderr is not None
+            DoneError: If the return code is not ok
 
         """
         if isinstance(ok_code, int):
@@ -275,7 +393,7 @@ class Done(_ShellfishBaseModel):
 
         Args:
             filepath: Filepath to write stdout to
-            append (bool): Flag to append to file or plain write to file
+            append: Append to the file instead of overwriting it
 
         """
         fs.write_bytes(Path(filepath), self.stdout.encode("utf-8"), append=append)
@@ -294,7 +412,7 @@ class Done(_ShellfishBaseModel):
 
         Args:
             filepath: Filepath of location to write stderr
-            append (bool): Flag to append to file or plain write to file
+            append: Append to the file instead of overwriting it
 
         """
         fs.write_bytes(Path(filepath), self.stderr.encode("utf-8"), append=append)
@@ -346,13 +464,33 @@ class Done(_ShellfishBaseModel):
     def json_parse_stdout(
         self, *, jsonc: bool = False, jsonl: bool = False, ndjson: bool = False
     ) -> Any:
-        """Return json parsed stdout"""
+        """Return json parsed stdout
+
+        Args:
+            jsonc: Parse stdout as jsonc (json with comments)
+            jsonl: Parse stdout as jsonl (json-lines)
+            ndjson: Parse stdout as ndjson (newline delimited json)
+
+        Returns:
+            The parsed stdout
+
+        """
         return JSON.loads(self.stdout, jsonc=jsonc, jsonl=jsonl, ndjson=ndjson)
 
     def json_parse_stderr(
         self, *, jsonc: bool = False, jsonl: bool = False, ndjson: bool = False
     ) -> Any:
-        """Return json parsed stderr"""
+        """Return json parsed stderr
+
+        Args:
+            jsonc: Parse stderr as jsonc (json with comments)
+            jsonl: Parse stderr as jsonl (json-lines)
+            ndjson: Parse stderr as ndjson (newline delimited json)
+
+        Returns:
+            The parsed stderr
+
+        """
         return JSON.loads(self.stderr, jsonc=jsonc, jsonl=jsonl, ndjson=ndjson)
 
     def json_parse(
@@ -363,7 +501,18 @@ class Done(_ShellfishBaseModel):
         jsonl: bool = False,
         ndjson: bool = False,
     ) -> Any:
-        """Return json parsed stdout"""
+        """Return json parsed stdout (or stderr)
+
+        Args:
+            stderr: Parse stderr instead of stdout
+            jsonc: Parse as jsonc (json with comments)
+            jsonl: Parse as jsonl (json-lines)
+            ndjson: Parse as ndjson (newline delimited json)
+
+        Returns:
+            The parsed stdout, or the parsed stderr if `stderr` is True
+
+        """
         return (
             self.json_parse_stdout(jsonc=jsonc, jsonl=jsonl, ndjson=ndjson)
             if not stderr
@@ -378,14 +527,27 @@ class Done(_ShellfishBaseModel):
         jsonl: bool = False,
         ndjson: bool = False,
     ) -> Any:
-        """Return json parsed stdout (alias bc I keep flip-flopping the fn name)"""
+        """Alias for [json_parse][shellfish.done.Done.json_parse]
+
+        (bc I keep flip-flopping the fn name)
+
+        Args:
+            stderr: Parse stderr instead of stdout
+            jsonc: Parse as jsonc (json with comments)
+            jsonl: Parse as jsonl (json-lines)
+            ndjson: Parse as ndjson (newline delimited json)
+
+        Returns:
+            The parsed stdout, or the parsed stderr if `stderr` is True
+
+        """
         return self.json_parse(stderr=stderr, jsonc=jsonc, jsonl=jsonl, ndjson=ndjson)
 
     def grep(self, string: str) -> list[str]:
-        """Return lines in stdout that have
+        """Return lines in stdout that contain the given string
 
         Args:
-            string (str): String to search for
+            string: String to search for
 
         Returns:
             list[str]: List of strings of stdout lines containing the given

--- a/libs/shellfish/src/shellfish/exe.py
+++ b/libs/shellfish/src/shellfish/exe.py
@@ -19,7 +19,9 @@ if TYPE_CHECKING:
 
 __all__ = (
     "Exe",
+    "ExeABC",
     "ExeAsync",
+    "ExeConfig",
 )
 
 TExe = TypeVar("TExe", bound="ExeABC")
@@ -27,30 +29,59 @@ TExe = TypeVar("TExe", bound="ExeABC")
 
 @dataclass
 class ExeConfig:
+    """Serializable configuration for an [ExeABC][shellfish.exe.ExeABC] subclass"""
+
     cmd: str
+    """Name of (or path to) the executable"""
     subcmd: tuple[str, ...] | None = None
+    """Sub-command args always prepended to the exe's args"""
     abspath: str | None = None
+    """Resolved absolute path to the executable, if known/cached"""
     env: dict[str, str] | None = None
+    """Environment variables to run the executable with"""
     cwd: str | None = None
+    """Working directory to run the executable in"""
     shell: bool = False
+    """Run the executable through the shell"""
     verbose: bool = False
+    """Echo stdout/stderr of each run to the parent process"""
     timeout: float | int | None = None
+    """Timeout in seconds for each run; None for no timeout"""
     ok_code: int | set[int] = field(default_factory=lambda: {0})
+    """Return code(s) considered ok"""
     check: bool = False
+    """Raise [DoneError][shellfish.done.DoneError] if the return code is not ok"""
 
 
 class ExeABC:
+    """Base class for command/executable wrapper objects
+
+    Holds the defaults (env, cwd, timeout, ...) that each invocation of the
+    wrapped executable is run with. Subclassed by [Exe][shellfish.exe.Exe] and
+    [ExeAsync][shellfish.exe.ExeAsync], which make instances callable.
+    """
+
     cmd: str
+    """Name of (or path to) the executable"""
     subcmd: tuple[str, ...] | None = None
+    """Sub-command args always prepended to the exe's args"""
 
     abspath: str | None = None
+    """Resolved absolute path to the executable, if known/cached"""
     env: dict[str, str] | None = None
+    """Environment variables to run the executable with"""
     cwd: FsPath | None = None
+    """Working directory to run the executable in"""
     shell: bool = False
+    """Run the executable through the shell"""
     verbose: bool = False
+    """Echo stdout/stderr of each run to the parent process"""
     timeout: float | int | None = None
+    """Timeout in seconds for each run; None for no timeout"""
     ok_code: int | set[int] = 0
+    """Return code(s) considered ok"""
     check: bool = False
+    """Raise [DoneError][shellfish.done.DoneError] if the return code is not ok"""
 
     def __init__(
         self,
@@ -66,6 +97,21 @@ class ExeABC:
         timeout: float | int | None = None,
         verbose: bool = False,
     ) -> None:
+        """Create an exe wrapper for `cmd`
+
+        Args:
+            cmd: Name of (or path to) the executable
+            subcmd: Sub-command args always prepended to the exe's args
+            abspath: Absolute path to the executable; skips the `which` lookup
+            check: Raise `DoneError` if the return code is not ok
+            cwd: Working directory to run the executable in
+            env: Environment variables to run the executable with
+            ok_code: Return code (or collection of return codes) considered ok
+            shell: Run the executable through the shell
+            timeout: Timeout in seconds for each run; None for no timeout
+            verbose: Echo stdout/stderr of each run to the parent process
+
+        """
         self.cmd = cmd
         if subcmd is not None:
             self.subcmd = (subcmd,) if isinstance(subcmd, str) else tuple(subcmd)
@@ -86,11 +132,11 @@ class ExeABC:
         self.__post_init__()
 
     def __post_init__(self) -> None:
-        """Post-initialization"""
+        """Hook called at the end of `__init__`; a no-op subclasses may override"""
 
     @classmethod
     def _from_exe_config(cls: type[TExe], config: ExeConfig) -> TExe:
-        """Return a new instance from the config"""
+        """Return a new instance from an [ExeConfig][shellfish.exe.ExeConfig]"""
         return cls(
             cmd=config.cmd,
             subcmd=config.subcmd,
@@ -105,7 +151,7 @@ class ExeABC:
         )
 
     def _config(self) -> ExeConfig:
-        """Return the config"""
+        """Return this exe's settings as an [ExeConfig][shellfish.exe.ExeConfig]"""
         return ExeConfig(
             cmd=self.cmd,
             subcmd=self.subcmd,
@@ -120,7 +166,15 @@ class ExeABC:
         )
 
     def _which(self) -> str:
-        """Return the path to the exe"""
+        """Return (and cache) the absolute path to the exe
+
+        Returns:
+            Absolute path to the executable
+
+        Raises:
+            FileNotFoundError: If the executable is not found on the PATH
+
+        """
         if self.abspath is not None:
             return self.abspath
         _abspath = sh.which(self.cmd)
@@ -131,7 +185,15 @@ class ExeABC:
         return self.abspath
 
     def which(self) -> str:
-        """Return the path to the exe"""
+        """Return the absolute path to the exe
+
+        Returns:
+            Absolute path to the executable
+
+        Raises:
+            FileNotFoundError: If the executable is not found on the PATH
+
+        """
         return self._which()
 
     def _unredundify(
@@ -139,6 +201,7 @@ class ExeABC:
         popenargs: tuple[PopenArgs, ...],
         args: PopenArgs | None = None,
     ) -> tuple[str, ...]:
+        """Flatten args, dropping a leading repeat of `self.cmd` if present"""
         _args = popenargs if args is None else args
         if len(_args) == 1 and isinstance(_args[0], str):
             _args_list = _shplit(_args[0])
@@ -153,6 +216,7 @@ class ExeABC:
         popenargs: tuple[PopenArgs, ...],
         args: PopenArgs | None = None,
     ) -> PopenArgv:
+        """Return the full argv (`self.cmd` + flattened args) for a run"""
         argv = self._unredundify(popenargs, args)
         return (self.cmd, *argv)
 
@@ -171,6 +235,26 @@ class ExeABC:
         ok_code: int | list[int] | tuple[int, ...] | set[int] = 0,
         dryrun: bool = False,
     ) -> Done:
+        """Run the exe with the given args, overriding this exe's defaults
+
+        Args:
+            *popenargs: Args to run the exe with
+            args: Args to run the exe with (alternative to `*popenargs`)
+            env: Environment variables; defaults to `self.env`
+            extenv: Extend `os.environ` with `env` instead of replacing it
+            cwd: Working directory; defaults to `self.cwd`
+            shell: Run through the shell; or-ed with `self.shell`
+            check: Raise `DoneError` if the return code is not ok
+            verbose: Echo stdout/stderr; or-ed with `self.verbose`
+            input: Stdin to write to the process
+            timeout: Timeout in seconds; defaults to `self.timeout`
+            ok_code: Return code(s) considered ok; defaults to `self.ok_code`
+            dryrun: Do not actually run the process
+
+        Returns:
+            [Done][shellfish.done.Done] object for the finished process
+
+        """
         _args = self._cmdargs(popenargs, args)
         return sh.do(
             args=_args,
@@ -202,6 +286,27 @@ class ExeABC:
         timeout: float | int | None = None,
         verbose: bool = False,
     ) -> Done:
+        """Run the exe asynchronously, overriding this exe's defaults
+
+        Args:
+            *popenargs: Args to run the exe with
+            args: Args to run the exe with (alternative to `*popenargs`)
+            check: Raise `DoneError` if the return code is not ok
+            cwd: Working directory; defaults to `self.cwd`
+            dryrun: Do not actually run the process
+            env: Environment variables; defaults to `self.env`
+            extenv: Extend `os.environ` with `env` instead of replacing it
+            input: Stdin to write to the process
+            loop: Event loop to run in (unused; kept for signature compatibility)
+            ok_code: Return code(s) considered ok; defaults to `self.ok_code`
+            shell: Run through the shell; or-ed with `self.shell`
+            timeout: Timeout in seconds; defaults to `self.timeout`
+            verbose: Echo stdout/stderr; or-ed with `self.verbose`
+
+        Returns:
+            [Done][shellfish.done.Done] object for the finished process
+
+        """
         _args = self._cmdargs(popenargs, args)
         return await sh.do_async(
             args=_args,
@@ -224,6 +329,29 @@ class ExeABC:
 
 
 class Exe(ExeABC):
+    """Callable wrapper around an executable
+
+    Examples:
+        >>> from shellfish.exe import Exe
+        >>> git = Exe("git", subcmd="status", verbose=False)
+        >>> git.cmd
+        'git'
+        >>> git.subcmd
+        ('status',)
+        >>> git.ok_code
+        {0}
+
+        Calling the instance runs the executable and returns a
+        [Done][shellfish.done.Done] object:
+
+        ```python
+        done = git("--porcelain")
+        done.check()
+        print(done.stdout)
+        ```
+
+    """
+
     def __call__(
         self,
         *popenargs: PopenArgs,
@@ -239,6 +367,12 @@ class Exe(ExeABC):
         ok_code: int | list[int] | tuple[int, ...] | set[int] = 0,
         dryrun: bool = False,
     ) -> Done:
+        """Run the exe with the given args; see [do][shellfish.exe.ExeABC.do]
+
+        Returns:
+            [Done][shellfish.done.Done] object for the finished process
+
+        """
         return self._do(
             *popenargs,
             args=args,
@@ -256,6 +390,17 @@ class Exe(ExeABC):
 
 
 class ExeAsync(ExeABC):
+    """Awaitable wrapper around an executable
+
+    Same configuration as [Exe][shellfish.exe.Exe], but calling an instance
+    returns a coroutine:
+
+    ```python
+    git = ExeAsync("git")
+    done = await git("status", "--porcelain")
+    ```
+    """
+
     async def __call__(
         self,
         *popenargs: PopenArgs,
@@ -271,6 +416,12 @@ class ExeAsync(ExeABC):
         timeout: float | int | None = None,
         verbose: bool = False,
     ) -> Done:
+        """Run the exe asynchronously; see [do_async][shellfish.exe.ExeABC.do_async]
+
+        Returns:
+            [Done][shellfish.done.Done] object for the finished process
+
+        """
         return await self._do_async(
             *popenargs,
             args=args,

--- a/libs/shellfish/src/shellfish/osfs.py
+++ b/libs/shellfish/src/shellfish/osfs.py
@@ -12,47 +12,118 @@ from shellfish import batman
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+__all__ = (
+    "LIN",
+    "WIN",
+    "OsFsAbc",
+)
+
 
 class OsFsAbc(ABC):  # pragma: nocov
-    """Abstract base class for OS-specific fns"""
+    """Abstract base class for OS-specific symlink operations
+
+    Implemented by [LIN][shellfish.osfs.LIN] (linux/mac) and
+    [WIN][shellfish.osfs.WIN] (windows); all members are static methods, so the
+    subclasses are used as namespaces rather than instantiated.
+    """
 
     @staticmethod
     @abstractmethod
-    def link_dir(linkpath: str, targetpath: str, *, exist_ok: bool = False) -> None: ...
+    def link_dir(linkpath: str, targetpath: str, *, exist_ok: bool = False) -> None:
+        """Make a directory symlink
+
+        Args:
+            linkpath: Path to the link to be made
+            targetpath: Path to the target of the link to be made
+            exist_ok: Allow the link to already exist
+
+        """
+        ...
 
     @staticmethod
     @abstractmethod
     def link_dirs(
         link_target_tuples: list[tuple[str, str]], *, exist_ok: bool = False
-    ) -> None: ...
+    ) -> None:
+        """Make multiple directory symlinks
+
+        Args:
+            link_target_tuples: Iterable of `(link, target)` tuples
+            exist_ok: Allow the links to already exist
+
+        """
+        ...
 
     @staticmethod
     @abstractmethod
-    def link_file(
-        linkpath: str, targetpath: str, *, exist_ok: bool = False
-    ) -> None: ...
+    def link_file(linkpath: str, targetpath: str, *, exist_ok: bool = False) -> None:
+        """Make a file symlink
+
+        Args:
+            linkpath: Path to the link to be made
+            targetpath: Path to the target of the link to be made
+            exist_ok: Allow the link to already exist
+
+        """
+        ...
 
     @staticmethod
     @abstractmethod
     def link_files(
         link_target_tuples: list[tuple[str, str]], *, exist_ok: bool = False
-    ) -> None: ...
+    ) -> None:
+        """Make multiple file symlinks
+
+        Args:
+            link_target_tuples: Iterable of `(link, target)` tuples
+            exist_ok: Allow the links to already exist
+
+        """
+        ...
 
     @staticmethod
     @abstractmethod
-    def unlink_dir(link: str) -> None: ...
+    def unlink_dir(link: str) -> None:
+        """Unlink a directory symlink
+
+        Args:
+            link: Path to the symlink
+
+        """
+        ...
 
     @staticmethod
     @abstractmethod
-    def unlink_dirs(links: Iterable[str]) -> None: ...
+    def unlink_dirs(links: Iterable[str]) -> None:
+        """Unlink multiple directory symlinks
+
+        Args:
+            links: Iterable of paths to symlinks
+
+        """
+        ...
 
     @staticmethod
     @abstractmethod
-    def unlink_file(link: str) -> None: ...
+    def unlink_file(link: str) -> None:
+        """Unlink a file symlink
+
+        Args:
+            link: Path to the symlink
+
+        """
+        ...
 
     @staticmethod
     @abstractmethod
-    def unlink_files(links: Iterable[str]) -> None: ...
+    def unlink_files(links: Iterable[str]) -> None:
+        """Unlink multiple file symlinks
+
+        Args:
+            links: Iterable of paths to symlinks
+
+        """
+        ...
 
 
 # =============================================================================
@@ -73,9 +144,9 @@ class LIN(OsFsAbc):  # pragma: nocov
         """Make a directory symlink
 
         Args:
-            linkpath (str): Path to the link to be made
-            targetpath (str): Path to the target of the link to be made
-            exist_ok (str): Allow link to exist
+            linkpath: Path to the link to be made
+            targetpath: Path to the target of the link to be made
+            exist_ok: Allow link to exist
 
         """
         try:
@@ -94,7 +165,7 @@ class LIN(OsFsAbc):  # pragma: nocov
             link_target_tuples: Iterable of tuples of the form: (link, target)
                 or a dictionary mapping with key => value pairs of the form
                 link => target.
-            exist_ok (bool): Allow link to exist
+            exist_ok: Allow link to exist
 
         """
         for link, target in link_target_tuples:
@@ -105,9 +176,9 @@ class LIN(OsFsAbc):  # pragma: nocov
         """Make a file symlink
 
         Args:
-            linkpath (str): Path to the link to be made
-            targetpath (str): Path to the target of the link to be made
-            exist_ok (bool): Allow links to already exist
+            linkpath: Path to the link to be made
+            targetpath: Path to the target of the link to be made
+            exist_ok: Allow links to already exist
 
         """
         makedirs(path.split(linkpath)[0], exist_ok=True)
@@ -124,7 +195,7 @@ class LIN(OsFsAbc):  # pragma: nocov
         """Make multiple file symlinks
 
         Args:
-            exist_ok (bool): Allow links to already exist
+            exist_ok: Allow links to already exist
             link_target_tuples: Iterable of tuples of the form: (link, target)
                 or a dictionary mapping with key => value pairs of the form
                 link => target.
@@ -186,9 +257,9 @@ class WIN(OsFsAbc):  # pragma: nocov
         """Make a directory symlink
 
         Args:
-            linkpath (str): Path to the link to be made
-            targetpath (str): Path to the target of the link to be made
-            exist_ok (bool): If True, do not raise an exception if the link exists
+            linkpath: Path to the link to be made
+            targetpath: Path to the target of the link to be made
+            exist_ok: If True, do not raise an exception if the link exists
 
         """
         makedirs(path.split(linkpath)[0], exist_ok=True)
@@ -211,7 +282,7 @@ class WIN(OsFsAbc):  # pragma: nocov
             link_target_tuples: Iterable of tuples of the form: (link, target)
                 or a dictionary mapping with key => value pairs of the form
                 link => target.
-            exist_ok (bool): If True, do not raise an exception if the link(s) exist
+            exist_ok: If True, do not raise an exception if the link(s) exist
 
         """
         try:
@@ -230,9 +301,9 @@ class WIN(OsFsAbc):  # pragma: nocov
         """Make a file symlink
 
         Args:
-            linkpath (str): Path to the link to be made
-            targetpath (str): Path to the target of the link to be made
-            exist_ok (bool): If True, don't raise an exception if the link exists
+            linkpath: Path to the link to be made
+            targetpath: Path to the target of the link to be made
+            exist_ok: If True, don't raise an exception if the link exists
 
         """
         try:
@@ -254,7 +325,7 @@ class WIN(OsFsAbc):  # pragma: nocov
             link_target_tuples: Iterable of tuples of the form: (link, target)
                 or a dictionary mapping with key => value pairs of the form
                 link => target.
-            exist_ok (bool): If True, don't raise an exception if the link exists
+            exist_ok: If True, don't raise an exception if the link exists
 
         """
         try:
@@ -303,7 +374,7 @@ class WIN(OsFsAbc):  # pragma: nocov
         """Unlink a file symlink given a path to the symlink
 
         Args:
-            link (str): path to the symlink
+            link: path to the symlink
 
         """
         try:

--- a/libs/shellfish/src/shellfish/process.py
+++ b/libs/shellfish/src/shellfish/process.py
@@ -57,7 +57,24 @@ _OS_ENVIRON_ATTRS = set(dir(environ))
 
 @contextmanager
 def tmpenv(**kwargs: str) -> Generator[type[Env], Any, None]:
-    """Context manager for Env"""
+    """Context manager that restores `os.environ` on exit
+
+    Args:
+        **kwargs: Environment variables to set for the duration of the block
+
+    Yields:
+        The [Env][shellfish.process.Env] proxy
+
+    Examples:
+        >>> from shellfish.process import tmpenv
+        >>> with tmpenv(SOME_TMP_VAR="value") as e:
+        ...     e.SOME_TMP_VAR
+        'value'
+        >>> import os
+        >>> "SOME_TMP_VAR" in os.environ
+        False
+
+    """
     old_env = dict(environ)
     if kwargs:
         env.update(kwargs)
@@ -69,6 +86,13 @@ def tmpenv(**kwargs: str) -> Generator[type[Env], Any, None]:
 
 
 class _EnvObjMeta(type):
+    """Metaclass giving [Env][shellfish.process.Env] mapping + attr access
+
+    Implemented on the metaclass so that the operations work on the `Env` class
+    itself (`Env.SOME_VAR`, `'SOME_VAR' in Env`) rather than on instances. Every
+    operation proxies straight through to `os.environ`.
+    """
+
     def __contains__(cls, key: str) -> bool:
         return key in environ
 
@@ -110,37 +134,62 @@ class _EnvObjMeta(type):
         return cls.__setitem__(key, value)
 
     def update(self, d: dict[str, str]) -> None:
+        """Update the environment from a dict of env-var names to values"""
         return environ.update(d)
 
     def update_from_dict(self, d: dict[str, str]) -> None:
+        """Alias for [update][shellfish.process.Env.update]"""
         return self.update(d)
 
     def get(self, key: str, default: str | None = None) -> str:
+        """Return the value for `key`, or `default` if it is not set
+
+        Args:
+            key: Environment variable name
+            default: Value to return if `key` is not set
+
+        Returns:
+            The environment variable's value
+
+        Raises:
+            KeyError: If `key` is not set and no `default` is given
+
+        """
         if default is None:
             return environ[key]
         return environ.get(key, default)
 
     def setdefault(self, key: str, default: str) -> str:
+        """Set `key` to `default` if unset, and return the resulting value"""
         return environ.setdefault(key, default)
 
     def clear(self) -> None:
+        """Remove all environment variables"""
         return environ.clear()
 
     def keys(self) -> KeysView[str]:
+        """Return a view of the environment variable names"""
         return environ.keys()
 
     def values(self) -> ValuesView[str]:
+        """Return a view of the environment variable values"""
         return environ.values()
 
     def items(self) -> ItemsView[str, str]:
+        """Return a view of the environment `(name, value)` pairs"""
         return environ.items()
 
     def asdict(cls) -> dict[str, str]:
+        """Return the environment as a plain dict"""
         return dict(environ.items())
 
 
 class Env(metaclass=_EnvObjMeta):
-    """Env with attr access
+    """`os.environ` proxy with attribute access
+
+    Not meant to be instantiated — use the class itself (or its `env`/`ENV`
+    aliases). Attribute, item, and mapping access all read and write the live
+    `os.environ`; unset variables read as `None` instead of raising.
 
     Examples:
         >>> from os import environ

--- a/libs/shellfish/src/shellfish/sh.py
+++ b/libs/shellfish/src/shellfish/sh.py
@@ -386,12 +386,20 @@ IS_WIN: bool = is_win()
 
 
 class FlagMeta(type):
-    """Meta class"""
+    """Metaclass turning attribute access on [Flag][shellfish.sh.Flag] into flags"""
 
     @staticmethod
     @cache
     def attr2flag(string: str) -> str:
-        """Convert and return attr to string"""
+        """Return an attribute name as a cli flag (underscores to dashes)
+
+        Args:
+            string: Attribute name to convert
+
+        Returns:
+            The attribute name with underscores replaced by dashes
+
+        """
         return string.replace("_", "-")
 
     def __getattr__(self, name: str) -> str:
@@ -399,18 +407,33 @@ class FlagMeta(type):
 
 
 class Flag(metaclass=FlagMeta):
-    """Flag obj
+    """Namespace that turns any attribute into the corresponding cli flag
+
+    Leading underscores become leading dashes and inner underscores become
+    dashes, so `Flag.__dry_run` is `'--dry-run'`. Not meant to be instantiated.
 
     Examples:
         >>> Flag.__help
         '--help'
         >>> Flag._v
         '-v'
+        >>> Flag.__dry_run
+        '--dry-run'
 
     """
 
 
 def mkenv(env: dict[str, str], *, extenv: bool = True) -> dict[str, str]:
+    """Return the environment dict to run a subprocess with
+
+    Args:
+        env: Environment variables for the subprocess
+        extenv: Extend `os.environ` with `env` instead of replacing it
+
+    Returns:
+        The environment variables dict
+
+    """
     if extenv:
         return {**dict(environ), **env}
     return env
@@ -622,16 +645,16 @@ def _do(
         shell: Run in shell or sub-shell
         check: Check the outputs (generally useless)
         input: Stdin to give to the subprocess
-        verbose (bool): Flag to write the subprocess stdout and stderr to
+        verbose: Flag to write the subprocess stdout and stderr to
             sys.stdout and sys.stderr
-        tee (bool): Flag to tee the subprocess stdout and stderr to sys.stdout/stderr
+        tee: Flag to tee the subprocess stdout and stderr to sys.stdout/stderr
         text: Flag to decode the output as text
-        timeout (Optional[int]): Timeout in seconds for the process if not None
-        ok_code (Union[int, Sequence[int]]): Code(s) to consider as OK
-        dryrun (bool): Flag to not run the subprocess and return faux Done
+        timeout: Timeout in seconds for the process if not None
+        ok_code: Code(s) to consider as OK
+        dryrun: Flag to not run the subprocess and return a faux Done
 
     Returns:
-        Finished PRun object which is a dictionary, so a dictionary
+        [Done][shellfish.done.Done] object for the finished subprocess
 
     Raises:
         ValueError: If args has pipe character (`|`)
@@ -739,7 +762,7 @@ def do(
         tee (bool): Flag to tee the subprocess stdout and stderr to sys.stdout/stderr
         verbose (bool): Flag to write the subprocess stdout and stderr to
             sys.stdout and sys.stderr
-        timeout (Optional[int]): Timeout in seconds for the process if not None
+        timeout: Timeout in seconds for the process if not None
         ok_code: Return code(s) to check against
         dryrun: Don't run the subprocess
 
@@ -797,7 +820,7 @@ def shell(
         input: Stdin to give to the subprocess
         verbose (bool): Flag to write the subprocess stdout and stderr to
             sys.stdout and sys.stderr
-        timeout (Optional[int]): Timeout in seconds for the process if not None
+        timeout: Timeout in seconds for the process if not None
         ok_code: Return code(s) to check if ok
         dryrun: Don't run the subprocess
 
@@ -926,7 +949,7 @@ async def _do_async(
         input: Stdin to give to the subprocess
         verbose (bool): Flag to write the subprocess stdout and stderr to
             sys.stdout and sys.stderr
-        timeout (Optional[int]): Timeout in seconds for the process if not None
+        timeout: Timeout in seconds for the process if not None
         ok_code: Return code(s) to check if ok
         dryrun: Don't run the subprocess
 
@@ -1043,7 +1066,7 @@ async def do_async(
         input: Stdin to give to the subprocess
         verbose (bool): Flag to write the subprocess stdout and stderr to
             sys.stdout and sys.stderr
-        timeout (Optional[int]): Timeout in seconds for the process if not None
+        timeout: Timeout in seconds for the process if not None
         ok_code: Return code(s) that are considered OK (Default value = 0)
         dryrun (bool): Flag to not run the subprocess but return a Done object
 
@@ -1103,7 +1126,7 @@ async def doa(
         input: Stdin to give to the subprocess
         verbose (bool): Flag to write the subprocess stdout and stderr to
             sys.stdout and sys.stderr
-        timeout (Optional[int]): Timeout in seconds for the process if not None
+        timeout: Timeout in seconds for the process if not None
         ok_code: Return code(s) that are considered OK (Default value = 0)
         dryrun (bool): Flag to not run the subprocess but return a Done object
         extenv: Extend environment with the current environment (Default value = True)
@@ -1139,7 +1162,11 @@ async def doa(
 
 
 class LIN(_LIN):
-    """Linux (and Mac) shell commands/methods container"""
+    """Linux (and Mac) shell commands/methods container
+
+    Extends [shellfish.osfs.LIN][] with `rsync`/`sync` helpers. All members are
+    static methods; the class is used as a namespace, not instantiated.
+    """
 
     @staticmethod
     def rsync_args(
@@ -1316,9 +1343,14 @@ class LIN(_LIN):
 
 
 class WIN(_WIN):
-    """Windows shell commands/methods container"""
+    """Windows shell commands/methods container
+
+    Extends [shellfish.osfs.WIN][] with `robocopy`/`sync` helpers. All members
+    are static methods; the class is used as a namespace, not instantiated.
+    """
 
     _MAX_CMD_LENGTH: int = 8192
+    """Max length of a single windows command line, in characters"""
 
     @staticmethod
     def robocopy_args(
@@ -1641,7 +1673,7 @@ def which(cmd: str, path: str | None = None) -> str | None:
         path (str): System path to use
 
     Returns:
-        Optional[str]: path to command/exe
+        Path to the command/exe, or None if not found
 
     """
     return _which(cmd, path=path)
@@ -1655,7 +1687,7 @@ def where(cmd: str, path: str | None = None) -> str | None:
         path (str): System path to use
 
     Returns:
-        Optional[str]: path to command/exe
+        Path to the command/exe, or None if not found
 
     """
     return which(cmd, path=path)
@@ -1670,7 +1702,7 @@ def which_lru(cmd: str, path: str | None = None) -> str | None:
         path (str): System path to use
 
     Returns:
-        Optional[str]: path to command/exe
+        Path to the command/exe, or None if not found
 
     """
     return which(cmd, path=path)

--- a/libs/shellfish/src/shellfish/sp.py
+++ b/libs/shellfish/src/shellfish/sp.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+"""sp = subprocess wrappers"""
+
 from __future__ import annotations
 
 import sys
@@ -51,8 +53,12 @@ __all__ = (
     "CompletedProcess",
     "CompletedProcessDict",
     "Popen",
+    "ProcessDt",
     "completed_process_dict",
+    "pcheck",
     "run",
+    "run_dtee",
+    "run_tee",
     "runb",
     "runs",
 )
@@ -73,20 +79,39 @@ class ProcessDt:
     """
 
     ti: float
+    """Time the process started (seconds since epoch)"""
     tf: float
+    """Time the process finished (seconds since epoch)"""
     dt: float
+    """Time the process took to run (seconds; `tf - ti`)"""
     __slots__ = ("dt", "tf", "ti")
 
     @classmethod
     def from_titf(cls, ti: float, tf: float) -> ProcessDt:
+        """Return a ProcessDt with `dt` computed from start/finish times
+
+        Args:
+            ti: Time the process started (seconds since epoch)
+            tf: Time the process finished (seconds since epoch)
+
+        Returns:
+            ProcessDt object
+
+        """
         return cls(ti=ti, tf=tf, dt=tf - ti)
 
 
 class CompletedProcessDict(TypedDict):
+    """`subprocess.CompletedProcess` as a typed-dict"""
+
     args: list[str]
+    """Command args the process was run with"""
     stdout: str
+    """Standard output (stdout) of the process"""
     stderr: str
+    """Standard error (stderr) of the process"""
     returncode: int
+    """Exit status of the process"""
 
 
 def completed_process_dict(
@@ -139,11 +164,8 @@ def pcheck(
         process: CompletedProcess object
         ok_code: OK code or sequence of codes, default is 0
 
-    Returns:
-        None
-
     Raises:
-        CompletedProcessError: if process.returncode not in ok_code
+        CalledProcessError: if process.returncode is not ok
 
     """
     if isinstance(ok_code, int):
@@ -181,6 +203,34 @@ def runb(
     ok_code: int | list[int] | tuple[int, ...] | set[int] = 0,
     **other_popen_kwargs: Any,
 ) -> CompletedProcess[bytes]:
+    """Run a command capturing stdout/stderr as bytes
+
+    Thin wrapper around `subprocess.run` with `text=False` and an `ok_code`
+    aware `check`.
+
+    Args:
+        args: Command args to run
+        executable: Replacement program to execute
+        stdin: Stdin file/handle for the process
+        input: Stdin to write to the process
+        stdout: Stdout file/handle for the process
+        stderr: Stderr file/handle for the process
+        shell: Run the command through the shell
+        cwd: Working directory to run the command in
+        timeout: Timeout in seconds; None for no timeout
+        capture_output: Capture stdout and stderr
+        check: Check the return code against `ok_code`
+        env: Environment variables to run the command with
+        ok_code: Return code (or collection of return codes) considered ok
+        **other_popen_kwargs: Additional kwargs forwarded to `subprocess.run`
+
+    Returns:
+        `subprocess.CompletedProcess` with bytes stdout/stderr
+
+    Raises:
+        CalledProcessError: If `check` and the return code is not ok
+
+    """
     process = run(
         args=args,
         input=input,
@@ -218,7 +268,34 @@ def runs(
     ok_code: int | list[int] | tuple[int, ...] | set[int] = 0,
     **other_popen_kwargs: Any,
 ) -> CompletedProcess[str]:
-    """Run command with txt output"""
+    """Run a command capturing stdout/stderr as strings
+
+    Thin wrapper around `subprocess.run` with `text=True` and an `ok_code`
+    aware `check`.
+
+    Args:
+        args: Command args to run
+        executable: Replacement program to execute
+        stdin: Stdin file/handle for the process
+        input: Stdin to write to the process
+        stdout: Stdout file/handle for the process
+        stderr: Stderr file/handle for the process
+        shell: Run the command through the shell
+        cwd: Working directory to run the command in
+        timeout: Timeout in seconds; None for no timeout
+        capture_output: Capture stdout and stderr
+        check: Check the return code against `ok_code`
+        env: Environment variables to run the command with
+        ok_code: Return code (or collection of return codes) considered ok
+        **other_popen_kwargs: Additional kwargs forwarded to `subprocess.run`
+
+    Returns:
+        `subprocess.CompletedProcess` with str stdout/stderr
+
+    Raises:
+        CalledProcessError: If `check` and the return code is not ok
+
+    """
     process = run(
         args=args,
         input=input,
@@ -248,6 +325,27 @@ def run_dtee(
     shell: bool = False,
     timeout: float | None = None,
 ) -> tuple[CompletedProcess[bytes], ProcessDt]:
+    """Run a command, tee-ing stdout/stderr, and time it
+
+    Streams the process' stdout/stderr to this process' stdout/stderr as they
+    arrive, while also capturing them.
+
+    Args:
+        args: Command args to run
+        cwd: Working directory to run the command in
+        env: Environment variables to run the command with
+        input: Stdin to write to the process
+        shell: Run the command through the shell
+        timeout: Timeout in seconds; None for no timeout
+
+    Returns:
+        Tuple of the `subprocess.CompletedProcess` and its
+            [ProcessDt][shellfish.sp.ProcessDt] timing
+
+    Raises:
+        TimeoutExpired: If the process does not finish within `timeout`
+
+    """
     stdout_bio = BytesIO()
     stderr_bio = BytesIO()
     args_str = args2cmd(args)
@@ -318,6 +416,20 @@ def run_tee(
     shell: bool = False,
     timeout: float | None = None,
 ) -> CompletedProcess[bytes]:
+    """Run a command, tee-ing stdout/stderr; see [run_dtee][shellfish.sp.run_dtee]
+
+    Args:
+        args: Command args to run
+        cwd: Working directory to run the command in
+        env: Environment variables to run the command with
+        input: Stdin to write to the process
+        shell: Run the command through the shell
+        timeout: Timeout in seconds; None for no timeout
+
+    Returns:
+        `subprocess.CompletedProcess` with bytes stdout/stderr
+
+    """
     completed_process, _pdt = run_dtee(
         args=args,
         input=input,

--- a/libs/shellfish/src/shellfish/stdio.py
+++ b/libs/shellfish/src/shellfish/stdio.py
@@ -9,8 +9,20 @@ __all__ = ("Stdio",)
 
 
 class Stdio(IntEnum):
-    """Standard-io enum object"""
+    """Standard-io enum object; values are the standard file descriptors
+
+    Examples:
+        >>> from shellfish.stdio import Stdio
+        >>> Stdio.stdout
+        <Stdio.stdout: 1>
+        >>> int(Stdio.stderr)
+        2
+
+    """
 
     stdin = 0
+    """Standard input (fd 0)"""
     stdout = 1
+    """Standard output (fd 1)"""
     stderr = 2
+    """Standard error (fd 2)"""

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,7 +41,20 @@ nav:
       - requires: './libs/requires/requires.api.md'
       - listless: './libs/listless/listless.api.md'
       - jsonbourne: './libs/jsonbourne/jsonbourne.api.md'
-      - shellfish: './libs/shellfish/shellfish.api.md'
+      - shellfish:
+          - shellfish: './libs/shellfish/shellfish.api.md'
+          - shellfish.sh: './libs/shellfish/sh.md'
+          - shellfish.fs: './libs/shellfish/fs.md'
+          - shellfish.fs.promises: './libs/shellfish/fs.promises.md'
+          - shellfish.done: './libs/shellfish/done.md'
+          - shellfish.exe: './libs/shellfish/exe.md'
+          - shellfish.process: './libs/shellfish/process.md'
+          - shellfish.sp: './libs/shellfish/sp.md'
+          - shellfish.osfs: './libs/shellfish/osfs.md'
+          - shellfish.aios: './libs/shellfish/aios.md'
+          - shellfish.dotenv: './libs/shellfish/dotenv.md'
+          - shellfish.echo: './libs/shellfish/echo.md'
+          - shellfish.stdio: './libs/shellfish/stdio.md'
       - xtyping: './libs/xtyping/xtyping.api.md'
   # - Notebooks:
   #     - Cache Money: './notebooks/cache_money.ipynb'
@@ -130,29 +143,35 @@ plugins:
         python:
           inventories:
             - https://docs.python.org/3/objects.inv
+          # NOTE: these must point at the `src` dirs -- pointing at `libs/<lib>`
+          # picks up the stale pre-src-layout `libs/<lib>/<lib>` husks (which
+          # hold only __pycache__), so griffe collects empty packages. That is
+          # invisible when the libs happen to be installed in the venv, but
+          # breaks `nox -s mkdocs_serve`, which installs only the mkdocs deps.
           paths:
-            - libs/aiopen
-            - libs/asyncify
-            - libs/fmts
-            - libs/funkify
-            - libs/h5
-            - libs/jsonbourne
-            - libs/requires
-            - libs/listless
-            - libs/shellfish
-            - libs/xtyping
-          inherited_members: true
-          docstring_style: google
+            - libs/aiopen/src
+            - libs/asyncify/src
+            - libs/fmts/src
+            - libs/funkify/src
+            - libs/h5/src
+            - libs/jsonbourne/src
+            - libs/requires/src
+            - libs/listless/src
+            - libs/shellfish/src
+            - libs/xtyping/src
           options:
+            docstring_style: google
             docstring_options:
               ignore_init_summary: true
             docstring_section_style: list
             filters: ["!^_"]
             heading_level: 1
             inherited_members: true
+            members_order: source
             merge_init_into_class: true
             parameter_headings: true
             separate_signature: true
+            show_docstring_attributes: true
             show_root_heading: true
             show_root_full_path: false
             show_signature_annotations: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,11 @@ addopts = [
   "--doctest-modules",
   "--disable-warnings",
 ]
+# NOTE: the `libs/src/<pkg>` entries below are stale -- the real layout is
+# `libs/<pkg>/src/<pkg>`, so they collect nothing. Correcting them all at once
+# exposes pre-existing failures (a broken `fmts.timestamp` doctest, and
+# `jsonbourne/fastapi.py` needing the optional `starlette` dep), so only
+# shellfish is corrected here; the rest are left for a follow-up.
 testpaths = [
   "libs/src/aiopen",
   "libs/src/asyncify",
@@ -126,7 +131,7 @@ testpaths = [
   "libs/src/lager",
   "libs/src/listless",
   "libs/src/requires",
-  "libs/src/shellfish",
+  "libs/shellfish/src/shellfish",
   "libs/src/xtyping",
   "tests",
 ]


### PR DESCRIPTION
This started because I realized that shellfish docs for `Done` (and re-export from dgpy) did not include docs for attributes like `stdout`, `stderr`, and `returncode` because they didn't have docstrings.  I had Claude add those and organize the docs throughout shellfish to use consistent style. 

Also updated mkdocs config for shellfish to have docs by submodule rather than one HUGE list of functions/methods/etc.